### PR TITLE
add solution parsers

### DIFF
--- a/src/Sln/MsbuildReimpl.cs
+++ b/src/Sln/MsbuildReimpl.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+//WHY? no official sln parser avaiable https://github.com/Microsoft/msbuild/issues/1708#issuecomment-280693611
+
+namespace Microsoft.Build.Shared.XMakeAttributes { }
+
+namespace Microsoft.Build.Shared
+{
+    public static class ExceptionHandling
+    {
+        public static bool IsIoRelatedException(Exception ex)
+        {
+            return false;
+        }
+    }
+
+    public static class EscapingUtilities
+    {
+        internal static string UnescapeAll(string targetFrameworkMoniker)
+        {
+            return targetFrameworkMoniker;
+        }
+    }
+
+    public static class ProjectFileErrorUtilities
+    {
+        public static void VerifyThrowInvalidProjectFile(bool b, object e, object f, object c)
+        {
+        }
+
+        internal static void VerifyThrowInvalidProjectFile(bool v1, string v2, BuildEventFileInfo buildEventFileInfo, string v3, object slnFileMinUpgradableVersion, object slnFileMaxVersion)
+        {
+        }
+
+        internal static void VerifyThrowInvalidProjectFile(bool success, string v1, BuildEventFileInfo buildEventFileInfo, string v2, string projectName)
+        {
+        }
+
+        internal static void ThrowInvalidProjectFile(BuildEventFileInfo buildEventFileInfo, string v, string relativePath)
+        {
+        }
+    }
+
+    public class BuildEventFileInfo
+    {
+        public BuildEventFileInfo(string s)
+        {
+        }
+
+        public BuildEventFileInfo(string s, int a, int b)
+        {
+
+        }
+    }
+
+    public class InternalErrorException : Exception {
+        public InternalErrorException(string m) : base(m) { }
+        public InternalErrorException(string m, Exception iex) : base(m, iex) { }
+    }
+
+    public class ResourceUtilities
+    {
+        public static string FormatResourceString(out string e, out string x, string s, params object[] args)
+        {
+            e = x = "";
+            return string.Format(s, args);
+        }
+
+        public static string FormatResourceString(string s, params object[] args)
+        {
+            return string.Format(s, args);
+        }
+
+        public static string FormatString(string s, params object[] args)
+        {
+            return string.Format(s, args);
+        }
+
+        internal static void VerifyResourceStringExists(string resourceName)
+        {
+        }
+    }
+
+    // Source: https://github.com/Microsoft/msbuild/blob/1501e3b9e17da067ab7f1d2449720d0ad09448f2/src/Shared/FileUtilities.cs
+    public static class FileUtilities
+    {
+        internal static bool PathIsInvalid(string path)
+        {
+            if (path.IndexOfAny(InvalidPathChars) >= 0)
+            {
+                return true;
+            }
+
+            var filename = GetFileName(path);
+
+            return filename.IndexOfAny(InvalidFileNameChars) >= 0;
+        }
+
+        #region Used by top methods
+
+        internal static readonly char[] InvalidPathChars = new char[]
+        {
+            '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31
+        };
+
+        internal static readonly char[] InvalidFileNameChars = new char[]
+        {
+            '\"', '<', '>', '|', '\0',
+            (char)1, (char)2, (char)3, (char)4, (char)5, (char)6, (char)7, (char)8, (char)9, (char)10,
+            (char)11, (char)12, (char)13, (char)14, (char)15, (char)16, (char)17, (char)18, (char)19, (char)20,
+            (char)21, (char)22, (char)23, (char)24, (char)25, (char)26, (char)27, (char)28, (char)29, (char)30,
+            (char)31, ':', '*', '?', '\\', '/'
+        };
+
+        // Path.GetFileName does not react well to malformed filenames.
+        // For example, Path.GetFileName("a/b/foo:bar") returns bar instead of foo:bar
+        // It also throws exceptions on illegal path characters
+        private static string GetFileName(string path)
+        {
+            var lastDirectorySeparator = path.LastIndexOfAny(Slashes);
+            return lastDirectorySeparator >= 0 ? path.Substring(lastDirectorySeparator + 1) : path;
+        }
+
+        private static readonly char[] Slashes = { '/', '\\' };
+
+        #endregion
+    }
+}

--- a/src/Sln/Original/ErrorUtilities.cs
+++ b/src/Sln/Original/ErrorUtilities.cs
@@ -1,0 +1,803 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//source: https://raw.githubusercontent.com/Microsoft/msbuild/master/src/Shared/ErrorUtilities.cs
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+#if BUILDINGAPPXTASKS
+namespace Microsoft.Build.AppxPackage.Shared
+#else
+namespace Microsoft.Build.Shared
+#endif
+{
+    /// <summary>
+    /// This class contains methods that are useful for error checking and validation.
+    /// </summary>
+    internal static class ErrorUtilities
+    {
+        /// <summary>
+        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
+        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
+        /// then we can give them this undocumented environment variable as an immediate workaround.
+        /// </summary>
+        private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
+        private static readonly bool s_enableMSBuildDebugTracing = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDENABLEDEBUGTRACING"));
+
+        #region DebugTracing
+        public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
+        {
+            if (s_enableMSBuildDebugTracing)
+            {
+                if (parameters != null)
+                {
+                    Trace.WriteLine(String.Format(CultureInfo.CurrentCulture, formatstring, parameters), category);
+                }
+                else
+                {
+                    Trace.WriteLine(formatstring, category);
+                }
+            }
+        }
+        #endregion
+
+#if !BUILDINGAPPXTASKS
+        #region VerifyThrow -- for internal errors
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalError(string message, params object[] args)
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException(ResourceUtilities.FormatString(message, args));
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException(ResourceUtilities.FormatString(message, args), innerException);
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// Indicates the code path followed should not have been possible.
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalErrorUnreachable()
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException("Unreachable?");
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// Indicates the code path followed should not have been possible.
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowIfTypeDoesNotImplementToString(object param)
+        {
+#if DEBUG
+            // Check it has a real implementation of ToString()
+            if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
+            {
+                ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is null.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="parameter">The value of the argument.</param>
+        /// <param name="parameterName">Parameter that should not be null</param>
+        internal static void VerifyThrowInternalNull(object parameter, string parameterName)
+        {
+            if (parameter == null)
+            {
+                ThrowInternalError("{0} unexpectedly null", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when a lock on the specified object is not already held.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="locker">The object that should already have been used as a lock.</param>
+        internal static void VerifyThrowInternalLockHeld(object locker)
+        {
+#if !CLR2COMPATIBILITY
+            if (!Monitor.IsEntered(locker))
+            {
+                ThrowInternalError("Lock should already have been taken");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is null or zero length.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="parameterValue">The value of the argument.</param>
+        /// <param name="parameterName">Parameter that should not be null or zero length</param>
+        internal static void VerifyThrowInternalLength(string parameterValue, string parameterName)
+        {
+            VerifyThrowInternalNull(parameterValue, parameterName);
+
+            if (parameterValue.Length == 0)
+            {
+                ThrowInternalError("{0} unexpectedly empty", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is not a rooted path.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="value">Parameter that should be a rooted path</param>
+        internal static void VerifyThrowInternalRooted(string value)
+        {
+            if (!Path.IsPathRooted(value))
+            {
+                ThrowInternalError("{0} unexpectedly not a rooted path", value);
+            }
+        }
+
+        /// <summary>
+        /// This method should be used in places where one would normally put
+        /// an "assert". It should be used to validate that our assumptions are
+        /// true, where false would indicate that there must be a bug in our
+        /// code somewhere. This should not be used to throw errors based on bad
+        /// user input or anything that the user did wrong.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowInternalError(unformattedMessage, null, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        /// <param name="arg3"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowInvalidOperation
+
+        /// <summary>
+        /// Throws an InvalidOperationException with the specified resource string
+        /// </summary>
+        /// <param name="resourceName">Resource to use in the exception</param>
+        /// <param name="args">Formatting args.</param>
+        internal static void ThrowInvalidOperation(string resourceName, params object[] args)
+        {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
+            if (s_throwExceptions)
+            {
+                throw new InvalidOperationException(ResourceUtilities.FormatResourceString(resourceName, args));
+            }
+        }
+
+        /// <summary>
+        /// Throws an InvalidOperationException if the given condition is false.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowInvalidOperation(resourceName, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        /// <param name="arg3"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowArgument
+
+        /// <summary>
+        /// Throws an ArgumentException that can include an inner exception.
+        /// 
+        /// PERF WARNING: calling a method that takes a variable number of arguments
+        /// is expensive, because memory is allocated for the array of arguments -- do
+        /// not call this method repeatedly in performance-critical scenarios
+        /// </summary>
+        internal static void ThrowArgument
+        (
+            string resourceName,
+            params object[] args
+        )
+        {
+            ThrowArgument(null, resourceName, args);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException that can include an inner exception.
+        /// 
+        /// PERF WARNING: calling a method that takes a variable number of arguments
+        /// is expensive, because memory is allocated for the array of arguments -- do
+        /// not call this method repeatedly in performance-critical scenarios
+        /// </summary>
+        /// <remarks>
+        /// This method is thread-safe.
+        /// </remarks>
+        /// <param name="innerException">Can be null.</param>
+        /// <param name="resourceName"></param>
+        /// <param name="args"></param>
+        private static void ThrowArgument
+        (
+            Exception innerException,
+            string resourceName,
+            params object[] args
+        )
+        {
+#if DEBUG
+            ResourceUtilities.VerifyResourceStringExists(resourceName);
+#endif
+            if (s_throwExceptions)
+            {
+                throw new ArgumentException(ResourceUtilities.FormatResourceString(resourceName, args), innerException);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException if the given condition is false.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName);
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0);
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException that includes an inner exception, if
+        /// the given condition is false.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException">Can be null.</param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowArgument(innerException, resourceName, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowArgumentXXX
+
+        /// <summary>
+        /// Throws an argument out of range exception.
+        /// </summary>
+        internal static void ThrowArgumentOutOfRange(string parameterName)
+        {
+            if (s_throwExceptions)
+            {
+                throw new ArgumentOutOfRangeException(parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentOutOfRangeException using the given parameter name
+        /// if the condition is false.
+        /// </summary>
+        internal static void VerifyThrowArgumentOutOfRange(bool condition, string parameterName)
+        {
+            if (!condition)
+            {
+                ThrowArgumentOutOfRange(parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given string parameter is null
+        /// and ArgumentException if it has zero length.
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <param name="parameterName"></param>
+        internal static void VerifyThrowArgumentLength(string parameter, string parameterName)
+        {
+            VerifyThrowArgumentNull(parameter, parameterName);
+
+            if (parameter.Length == 0 && s_throwExceptions)
+            {
+                throw new ArgumentException(ResourceUtilities.FormatResourceString("Shared.ParameterCannotHaveZeroLength", parameterName));
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given string parameter is null
+        /// and ArgumentException if it has zero length.
+        /// </summary>
+        /// <param name="parameter"></param>
+        /// <param name="parameterName"></param>
+        internal static void VerifyThrowArgumentInvalidPath(string parameter, string parameterName)
+        {
+            VerifyThrowArgumentNull(parameter, parameterName);
+
+            if (FileUtilities.PathIsInvalid(parameter) && s_throwExceptions)
+            {
+                throw new ArgumentException(ResourceUtilities.FormatResourceString("Shared.ParameterCannotHaveInvalidPathChars", parameterName, parameter));
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException if the string has zero length, unless it is 
+        /// null, in which case no exception is thrown.
+        /// </summary>
+        internal static void VerifyThrowArgumentLengthIfNotNull(string parameter, string parameterName)
+        {
+            if (parameter != null && parameter.Length == 0 && s_throwExceptions)
+            {
+                throw new ArgumentException(ResourceUtilities.FormatResourceString("Shared.ParameterCannotHaveZeroLength", parameterName));
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given parameter is null.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="parameter"></param>
+        /// <param name="parameterName"></param>
+        internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
+        {
+            VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given parameter is null.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
+        {
+            if (parameter == null && s_throwExceptions)
+            {
+                // Most ArgumentNullException overloads append its own rather clunky multi-line message. 
+                // So use the one overload that doesn't.
+                throw new ArgumentNullException(
+                    ResourceUtilities.FormatResourceString(resourceName, parameterName),
+                    (Exception)null);
+            }
+        }
+
+        /// <summary>
+        /// Verifies the given arrays are not null and have the same length
+        /// </summary>
+        /// <param name="parameter1"></param>
+        /// <param name="parameter2"></param>
+        /// <param name="parameter1Name"></param>
+        /// <param name="parameter2Name"></param>
+        internal static void VerifyThrowArgumentArraysSameLength(Array parameter1, Array parameter2, string parameter1Name, string parameter2Name)
+        {
+            VerifyThrowArgumentNull(parameter1, parameter1Name);
+            VerifyThrowArgumentNull(parameter2, parameter2Name);
+
+            if (parameter1.Length != parameter2.Length && s_throwExceptions)
+            {
+                throw new ArgumentException(ResourceUtilities.FormatResourceString("Shared.ParametersMustHaveTheSameLength", parameter1Name, parameter2Name));
+            }
+        }
+
+        #endregion
+#endif
+    }
+}

--- a/src/Sln/Original/ProjectConfigurationInSolution.cs
+++ b/src/Sln/Original/ProjectConfigurationInSolution.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Represents a project configuration (e.g. "Debug|x86")</summary>
+//-----------------------------------------------------------------------
+
+//Source: https://raw.githubusercontent.com/Microsoft/msbuild/master/src/Build/Construction/Solution/ProjectConfigurationInSolution.cs
+
+using System;
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    /// This class represents an entry for a project configuration in a solution configuration.
+    /// </summary>
+    public sealed class ProjectConfigurationInSolution
+    {
+        /// <summary>
+        /// The configuration part of this configuration - e.g. "Debug", "Release"
+        /// </summary>
+        private string _configurationName;
+
+        /// <summary>
+        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
+        /// </summary>
+        private string _platformName;
+
+        /// <summary>
+        /// The full name of this configuration - e.g. "Debug|Any CPU"
+        /// </summary>
+        private string _fullName;
+
+        /// <summary>
+        /// True if this project configuration should be built as part of its parent solution configuration
+        /// </summary>
+        private bool _includeInBuild;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal ProjectConfigurationInSolution(string configurationName, string platformName, bool includeInBuild)
+        {
+            _configurationName = configurationName;
+            _platformName = RemoveSpaceFromAnyCpuPlatform(platformName);
+            _includeInBuild = includeInBuild;
+            _fullName = SolutionConfigurationInSolution.ComputeFullName(_configurationName, _platformName);
+        }
+
+        /// <summary>
+        /// The configuration part of this configuration - e.g. "Debug", "Release"
+        /// </summary>
+        public string ConfigurationName
+        {
+            get { return _configurationName; }
+        }
+
+        /// <summary>
+        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
+        /// </summary>
+        public string PlatformName
+        {
+            get { return _platformName; }
+        }
+
+        /// <summary>
+        /// The full name of this configuration - e.g. "Debug|Any CPU"
+        /// </summary>
+        public string FullName
+        {
+            get { return _fullName; }
+        }
+
+        /// <summary>
+        /// True if this project configuration should be built as part of its parent solution configuration
+        /// </summary>
+        public bool IncludeInBuild
+        {
+            get { return _includeInBuild; }
+        }
+
+        /// <summary>
+        /// This is a hacky method to remove the space in the "Any CPU" platform in project configurations.
+        /// The problem is that this platform is stored as "AnyCPU" in project files, but the project system
+        /// reports it as "Any CPU" to the solution configuration manager. Because of that all solution configurations
+        /// contain the version with a space in it, and when we try and give that name to actual projects, 
+        /// they have no clue what we're talking about. We need to remove the space in project platforms so that
+        /// the platform name matches the one used in projects.
+        /// </summary>
+        static private string RemoveSpaceFromAnyCpuPlatform(string platformName)
+        {
+            if (string.Compare(platformName, "Any CPU", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return "AnyCPU";
+            }
+
+            return platformName;
+        }
+    }
+}

--- a/src/Sln/Original/ProjectInSolution.cs
+++ b/src/Sln/Original/ProjectInSolution.cs
@@ -1,0 +1,505 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//source: https://raw.githubusercontent.com/Microsoft/msbuild/master/src/Build/Construction/Solution/ProjectInSolution.cs
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Security;
+using System.Text;
+using System.Xml;
+
+using XMakeAttributes = Microsoft.Build.Shared.XMakeAttributes;
+using ProjectFileErrorUtilities = Microsoft.Build.Shared.ProjectFileErrorUtilities;
+using BuildEventFileInfo = Microsoft.Build.Shared.BuildEventFileInfo;
+using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Build.Construction
+{
+    /// <remarks>
+    /// An enumeration defining the different types of projects we might find in an SLN.
+    /// </remarks>
+    public enum SolutionProjectType
+    {
+        /// <summary>
+        /// Everything else besides the below well-known project types.
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// C#, VB, and VJ# projects
+        /// </summary>
+        KnownToBeMSBuildFormat,
+        /// <summary>
+        /// Solution folders appear in the .sln file, but aren't buildable projects.
+        /// </summary>
+        SolutionFolder,
+        /// <summary>
+        /// ASP.NET projects
+        /// </summary>
+        WebProject,
+        /// <summary>
+        /// Web Deployment (.wdproj) projects
+        /// </summary>
+        WebDeploymentProject, //  MSBuildFormat, but Whidbey-era ones specify ProjectReferences differently
+        /// <summary>
+        /// Project inside an Enterprise Template project
+        /// </summary>
+        EtpSubProject,
+    }
+
+    internal struct AspNetCompilerParameters
+    {
+        internal string aspNetVirtualPath;      // For Venus projects only, Virtual path for web
+        internal string aspNetPhysicalPath;     // For Venus projects only, Physical path for web
+        internal string aspNetTargetPath;       // For Venus projects only, Target for output files
+        internal string aspNetForce;            // For Venus projects only, Force overwrite of target
+        internal string aspNetUpdateable;       // For Venus projects only, compiled web application is updateable
+        internal string aspNetDebug;            // For Venus projects only, generate symbols, etc.
+        internal string aspNetKeyFile;          // For Venus projects only, strong name key file.
+        internal string aspNetKeyContainer;     // For Venus projects only, strong name key container.
+        internal string aspNetDelaySign;        // For Venus projects only, delay sign strong name.
+        internal string aspNetAPTCA;            // For Venus projects only, AllowPartiallyTrustedCallers.
+        internal string aspNetFixedNames;       // For Venus projects only, generate fixed assembly names.
+    }
+
+    /// <remarks>
+    /// This class represents a project (or SLN folder) that is read in from a solution file.
+    /// </remarks>
+    public sealed class ProjectInSolution
+    {
+        #region Constants
+
+        /// <summary>
+        /// Characters that need to be cleansed from a project name.
+        /// </summary>
+        private static readonly char[] s_charsToCleanse = { '%', '$', '@', ';', '.', '(', ')', '\'' };
+
+        /// <summary>
+        /// Project names that need to be disambiguated when forming a target name
+        /// </summary>
+        internal static readonly string[] projectNamesToDisambiguate = { "Build", "Rebuild", "Clean", "Publish" };
+
+        /// <summary>
+        /// Character that will be used to replace 'unclean' ones.
+        /// </summary>
+        private const char cleanCharacter = '_';
+
+        #endregion
+
+        #region Member data
+
+        private SolutionProjectType _projectType;      // For example, KnownToBeMSBuildFormat, VCProject, WebProject, etc.
+        private string _projectName;          // For example, "WindowsApplication1"
+        private string _relativePath;         // Relative from .SLN file.  For example, "WindowsApplication1\WindowsApplication1.csproj"
+        private string _projectGuid;          // The unique Guid assigned to this project or SLN folder.
+        private List<string> _dependencies;     // A list of strings representing the Guids of the dependent projects.
+        private ArrayList _projectReferences; // A list of strings representing the guids of referenced projects.
+                                              // This is only used for VC/Venus projects
+        private string _parentProjectGuid;    // If this project (or SLN folder) is within a SLN folder, this is the Guid of the parent SLN folder.
+        private string _uniqueProjectName;    // For example, "MySlnFolder\MySubSlnFolder\WindowsApplication1"
+        private Hashtable _aspNetConfigurations;    // Key is configuration name, value is [struct] AspNetCompilerParameters
+        private SolutionFile _parentSolution; // The parent solution for this project
+        private string _targetFrameworkMoniker; // used for website projects, since they don't have a project file in which the
+                                                // target framework is stored.  Defaults to .NETFX 3.5
+
+#if FULL_SLN_PARSER
+        private List<string> _folderFiles; // A list of name and path of files inside a solution folder
+#endif
+
+        /// <summary>
+        /// The project configuration in given solution configuration
+        /// K: full solution configuration name (cfg + platform)
+        /// V: project configuration 
+        /// </summary>
+        private Dictionary<string, ProjectConfigurationInSolution> _projectConfigurations;
+
+        #endregion
+
+        #region Constructors
+
+        internal ProjectInSolution(SolutionFile solution)
+        {
+            _projectType = SolutionProjectType.Unknown;
+            _projectName = null;
+            _relativePath = null;
+            _projectGuid = null;
+            _dependencies = new List<string>();
+            _projectReferences = new ArrayList();
+            _parentProjectGuid = null;
+            _uniqueProjectName = null;
+            _parentSolution = solution;
+
+            // default to .NET Framework 3.5 if this is an old solution that doesn't explicitly say.
+            _targetFrameworkMoniker = ".NETFramework,Version=v3.5";
+
+            // This hashtable stores a AspNetCompilerParameters struct for each configuration name supported.
+            _aspNetConfigurations = new Hashtable(StringComparer.OrdinalIgnoreCase);
+
+            _projectConfigurations = new Dictionary<string, ProjectConfigurationInSolution>(StringComparer.OrdinalIgnoreCase);
+
+#if FULL_SLN_PARSER
+            _folderFiles = new List<string>();
+#endif
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// This project's name
+        /// </summary>
+        public string ProjectName
+        {
+            get { return _projectName; }
+            internal set { _projectName = value; }
+        }
+
+        /// <summary>
+        /// The path to this project file, relative to the solution location
+        /// </summary>
+        public string RelativePath
+        {
+            get { return _relativePath; }
+            internal set { _relativePath = value; }
+        }
+
+        /// <summary>
+        /// Returns the absolute path for this project
+        /// </summary>
+        public string AbsolutePath
+        {
+            get
+            {
+                return Path.Combine(this.ParentSolution.SolutionFileDirectory, this.RelativePath);
+            }
+        }
+
+        /// <summary>
+        /// The unique guid associated with this project, in "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}" form
+        /// </summary>
+        public string ProjectGuid
+        {
+            get { return _projectGuid; }
+            internal set { _projectGuid = value; }
+        }
+
+        /// <summary>
+        /// The guid, in "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}" form, of this project's 
+        /// parent project, if any. 
+        /// </summary>
+        public string ParentProjectGuid
+        {
+            get { return _parentProjectGuid; }
+            internal set { _parentProjectGuid = value; }
+        }
+
+        /// <summary>
+        /// List of guids, in "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}" form, mapping to projects 
+        /// that this project has a build order dependency on, as defined in the solution file. 
+        /// </summary>
+        public IReadOnlyList<string> Dependencies
+        {
+            get { return _dependencies.AsReadOnly(); }
+        }
+
+        /// <summary>
+        /// Configurations for this project, keyed off the configuration's full name, e.g. "Debug|x86"
+        /// </summary>
+        public IReadOnlyDictionary<string, ProjectConfigurationInSolution> ProjectConfigurations
+        {
+            get { return new ReadOnlyDictionary<string, ProjectConfigurationInSolution>(_projectConfigurations); }
+        }
+
+        /// <summary>
+        /// Extension of the project file, if any
+        /// </summary>
+        internal string Extension
+        {
+            get
+            {
+                return Path.GetExtension(_relativePath);
+            }
+        }
+
+        /// <summary>
+        /// This project's type.
+        /// </summary>
+        public SolutionProjectType ProjectType
+        {
+            get { return _projectType; }
+            set { _projectType = value; }
+        }
+
+        /// <summary>
+        /// Only applies to websites -- for other project types, references are 
+        /// either specified as Dependencies above, or as ProjectReferences in the
+        /// project file, which the solution doesn't have insight into. 
+        /// </summary>
+        internal ArrayList ProjectReferences
+        {
+            get { return _projectReferences; }
+        }
+
+        internal SolutionFile ParentSolution
+        {
+            get { return _parentSolution; }
+            set { _parentSolution = value; }
+        }
+
+        internal Hashtable AspNetConfigurations
+        {
+            get { return _aspNetConfigurations; }
+            set { _aspNetConfigurations = value; }
+        }
+
+        internal string TargetFrameworkMoniker
+        {
+            get { return _targetFrameworkMoniker; }
+            set { _targetFrameworkMoniker = value; }
+        }
+
+#if FULL_SLN_PARSER
+        /// <summary>
+        /// Only apply to solution folder
+        /// </summary>
+        public IReadOnlyList<string> FolderFiles
+        {
+            get { return _folderFiles.AsReadOnly(); }
+        }
+#endif
+
+#endregion
+
+        #region Methods
+
+        private bool _checkedIfCanBeMSBuildProjectFile = false;
+        private bool _canBeMSBuildProjectFile;
+        private string _canBeMSBuildProjectFileErrorMessage;
+
+        /// <summary>
+        /// Add the guid of a referenced project to our dependencies list.
+        /// </summary>
+        internal void AddDependency(string referencedProjectGuid)
+        {
+            _dependencies.Add(referencedProjectGuid);
+        }
+
+        /// <summary>
+        /// Set the requested project configuration. 
+        /// </summary>
+        internal void SetProjectConfiguration(string configurationName, ProjectConfigurationInSolution configuration)
+        {
+            _projectConfigurations[configurationName] = configuration;
+        }
+
+        /// <summary>
+        /// Looks at the project file node and determines (roughly) if the project file is in the MSBuild format.
+        /// The results are cached in case this method is called multiple times.
+        /// </summary>
+        /// <param name="errorMessage">Detailed error message in case we encounter critical problems reading the file</param>
+        /// <returns></returns>
+        internal bool CanBeMSBuildProjectFile(out string errorMessage)
+        {
+            if (_checkedIfCanBeMSBuildProjectFile)
+            {
+                errorMessage = _canBeMSBuildProjectFileErrorMessage;
+                return _canBeMSBuildProjectFile;
+            }
+
+            _checkedIfCanBeMSBuildProjectFile = true;
+            _canBeMSBuildProjectFile = false;
+            errorMessage = null;
+
+            try
+            {
+                // Read project thru a XmlReader with proper setting to avoid DTD processing
+                XmlReaderSettings xrSettings = new XmlReaderSettings();
+                xrSettings.DtdProcessing = DtdProcessing.Ignore;
+
+                XmlDocument projectDocument = new XmlDocument();
+
+                using (XmlReader xmlReader = XmlReader.Create(this.AbsolutePath, xrSettings))
+                {
+                    // Load the project file and get the first node    
+                    projectDocument.Load(xmlReader);
+                }
+
+                XmlElement mainProjectElement = null;
+
+                // The XML parser will guarantee that we only have one real root element,
+                // but we need to find it amongst the other types of XmlNode at the root.
+                foreach (XmlNode childNode in projectDocument.ChildNodes)
+                {
+                    if (childNode.NodeType == XmlNodeType.Element)
+                    {
+                        mainProjectElement = (XmlElement)childNode;
+                        break;
+                    }
+                }
+
+                if (mainProjectElement != null && mainProjectElement.LocalName == "Project")
+                {
+                    _canBeMSBuildProjectFile = true;
+                    return _canBeMSBuildProjectFile;
+                }
+            }
+            // catch all sorts of exceptions - if we encounter any problems here, we just assume the project file is not
+            // in the MSBuild format
+
+            // handle errors in path resolution
+            catch (SecurityException e)
+            {
+                _canBeMSBuildProjectFileErrorMessage = e.Message;
+            }
+            // handle errors in path resolution
+            catch (NotSupportedException e)
+            {
+                _canBeMSBuildProjectFileErrorMessage = e.Message;
+            }
+            // handle errors in loading project file
+            catch (IOException e)
+            {
+                _canBeMSBuildProjectFileErrorMessage = e.Message;
+            }
+            // handle errors in loading project file
+            catch (UnauthorizedAccessException e)
+            {
+                _canBeMSBuildProjectFileErrorMessage = e.Message;
+            }
+            // handle XML parsing errors (when reading project file)
+            // this is not critical, since the project file doesn't have to be in XML formal
+            catch (XmlException)
+            {
+            }
+
+            errorMessage = _canBeMSBuildProjectFileErrorMessage;
+
+            return _canBeMSBuildProjectFile;
+        }
+
+        /// <summary>
+        /// Find the unique name for this project, e.g. SolutionFolder\SubSolutionFolder\ProjectName
+        /// </summary>
+        internal string GetUniqueProjectName()
+        {
+            if (_uniqueProjectName == null)
+            {
+                // EtpSubProject and Venus projects have names that are already unique.  No need to prepend the SLN folder.
+                if ((this.ProjectType == SolutionProjectType.WebProject) || (this.ProjectType == SolutionProjectType.EtpSubProject))
+                {
+                    _uniqueProjectName = CleanseProjectName(this.ProjectName);
+                }
+                else
+                {
+                    // This is "normal" project, which in this context means anything non-Venus and non-EtpSubProject.
+
+                    // If this project has a parent SLN folder, first get the full unique name for the SLN folder,
+                    // and tack on trailing backslash.
+                    string uniqueName = String.Empty;
+
+                    if (this.ParentProjectGuid != null)
+                    {
+                        ProjectInSolution proj;
+                        if (!this.ParentSolution.ProjectsByGuid.TryGetValue(this.ParentProjectGuid, out proj))
+                        {
+                            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj != null, "SubCategoryForSolutionParsingErrors",
+                                new BuildEventFileInfo(_parentSolution.FullPath), "SolutionParseNestedProjectError");
+                        }
+
+                        uniqueName = proj.GetUniqueProjectName() + "\\";
+                    }
+
+                    // Now tack on our own project name, and cache it in the ProjectInSolution object for future quick access.
+                    _uniqueProjectName = CleanseProjectName(uniqueName + this.ProjectName);
+                }
+            }
+
+            return _uniqueProjectName;
+        }
+
+        /// <summary>
+        /// Changes the unique name of the project.
+        /// </summary>
+        internal void UpdateUniqueProjectName(string newUniqueName)
+        {
+            ErrorUtilities.VerifyThrowArgumentLength(newUniqueName, "newUniqueName");
+
+            _uniqueProjectName = newUniqueName;
+        }
+
+#if FULL_SLN_PARSER
+        /// <summary>
+        /// Add the folder file.
+        /// </summary>
+        internal void AddFolderFile(string relativeFilePath)
+        {
+            _folderFiles.Add(relativeFilePath);
+        }
+#endif
+
+        /// <summary>
+        /// Cleanse the project name, by replacing characters like '@', '$' with '_'
+        /// </summary>
+        /// <param name="projectName">The name to be cleansed</param>
+        /// <returns>string</returns>
+        static private string CleanseProjectName(string projectName)
+        {
+            ErrorUtilities.VerifyThrow(projectName != null, "Null strings not allowed.");
+
+            // If there are no special chars, just return the original string immediately.
+            // Don't even instantiate the StringBuilder.
+            int indexOfChar = projectName.IndexOfAny(s_charsToCleanse);
+            if (indexOfChar == -1)
+            {
+                return projectName;
+            }
+
+            // This is where we're going to work on the final string to return to the caller.
+            StringBuilder cleanProjectName = new StringBuilder(projectName);
+
+            // Replace each unclean character with a clean one            
+            foreach (char uncleanChar in s_charsToCleanse)
+            {
+                cleanProjectName.Replace(uncleanChar, cleanCharacter);
+            }
+
+            return cleanProjectName.ToString();
+        }
+
+        /// <summary>
+        /// If the unique project name provided collides with one of the standard Solution project
+        /// entry point targets (Build, Rebuild, Clean, Publish), then disambiguate it by prepending the string "Solution:"
+        /// </summary>
+        /// <param name="uniqueProjectName">The unique name for the project</param>
+        /// <returns>string</returns>
+        static internal string DisambiguateProjectTargetName(string uniqueProjectName)
+        {
+            // Test our unique project name against those names that collide with Solution
+            // entry point targets
+            foreach (string projectName in projectNamesToDisambiguate)
+            {
+                if (String.Compare(uniqueProjectName, projectName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    // Prepend "Solution:" so that the collision is resolved, but the
+                    // log of the solution project still looks reasonable.
+                    return "Solution:" + uniqueProjectName;
+                }
+            }
+
+            return uniqueProjectName;
+        }
+
+#endregion
+
+#region Constants
+
+        internal const int DependencyLevelUnknown = -1;
+        internal const int DependencyLevelBeingDetermined = -2;
+
+#endregion
+    }
+}

--- a/src/Sln/Original/SolutionConfigurationInSolution.cs
+++ b/src/Sln/Original/SolutionConfigurationInSolution.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Represents a solution configuration (e.g. "Debug|x86")</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Build.Construction
+{
+    /// <summary>
+    /// This represents an entry for a solution configuration
+    /// </summary>
+    public sealed class SolutionConfigurationInSolution
+    {
+        /// <summary>
+        /// Default separator between configuration and platform in configuration
+        /// full names
+        /// </summary>
+        internal const char ConfigurationPlatformSeparator = '|';
+
+        /// <summary>
+        /// The configuration part of this configuration - e.g. "Debug", "Release"
+        /// </summary>
+        private string _configurationName;
+
+        /// <summary>
+        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
+        /// </summary>
+        private string _platformName;
+
+        /// <summary>
+        /// The full name of this configuration - e.g. "Debug|Any CPU"
+        /// </summary>
+        private string _fullName;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal SolutionConfigurationInSolution(string configurationName, string platformName)
+        {
+            _configurationName = configurationName;
+            _platformName = platformName;
+            _fullName = ComputeFullName(configurationName, platformName);
+        }
+
+        /// <summary>
+        /// The configuration part of this configuration - e.g. "Debug", "Release"
+        /// </summary>
+        public string ConfigurationName
+        {
+            get { return _configurationName; }
+        }
+
+        /// <summary>
+        /// The platform part of this configuration - e.g. "Any CPU", "Win32"
+        /// </summary>
+        public string PlatformName
+        {
+            get { return _platformName; }
+        }
+
+        /// <summary>
+        /// The full name of this configuration - e.g. "Debug|Any CPU"
+        /// </summary>
+        public string FullName
+        {
+            get { return _fullName; }
+        }
+
+        /// <summary>
+        /// Given a configuration name and a platform name, compute the full name 
+        /// of this configuration
+        /// </summary>
+        internal static string ComputeFullName(string configurationName, string platformName)
+        {
+            // Some configurations don't have the platform part
+            if ((platformName != null) && (platformName.Length > 0))
+            {
+                return String.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", configurationName, ConfigurationPlatformSeparator, platformName);
+            }
+            else
+            {
+                return configurationName;
+            }
+        }
+    }
+}

--- a/src/Sln/Original/SolutionFile.cs
+++ b/src/Sln/Original/SolutionFile.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Build.Construction
         private const string vjProjectGuid = "{E6FDF86B-F3D1-11D4-8576-0002A516ECE8}";
         private const string vcProjectGuid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
         private const string fsProjectGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
+        private const string cpsFsProjectGuid = "{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}";
         private const string dbProjectGuid = "{C8D11400-126E-41CD-887F-60BD40844F9E}";
         private const string wdProjectGuid = "{2CFEAB61-6A3B-4EB8-B523-560B4BEEF521}";
         private const string webProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
@@ -1293,6 +1294,7 @@ namespace Microsoft.Build.Construction
                 (String.Compare(projectTypeGuid, cpsCsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
                 (String.Compare(projectTypeGuid, cpsVbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
                 (String.Compare(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, cpsFsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
                 (String.Compare(projectTypeGuid, dbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
                 (String.Compare(projectTypeGuid, vjProjectGuid, StringComparison.OrdinalIgnoreCase) == 0))
             {

--- a/src/Sln/Original/SolutionFile.cs
+++ b/src/Sln/Original/SolutionFile.cs
@@ -1,0 +1,1650 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+//Source: https://raw.githubusercontent.com/Microsoft/msbuild/master/src/Build/Construction/Solution/SolutionFile.cs
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Xml;
+using System.IO;
+using System.Text;
+using System.Globalization;
+using System.Security;
+using System.Text.RegularExpressions;
+
+using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
+using VisualStudioConstants = Microsoft.Build.Shared.VisualStudioConstants;
+using ProjectFileErrorUtilities = Microsoft.Build.Shared.ProjectFileErrorUtilities;
+using BuildEventFileInfo = Microsoft.Build.Shared.BuildEventFileInfo;
+using ResourceUtilities = Microsoft.Build.Shared.ResourceUtilities;
+using ExceptionUtilities = Microsoft.Build.Shared.ExceptionHandling;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Build.Construction
+{
+    /// <remarks>
+    /// This class contains the functionality to parse a solution file and return a corresponding
+    /// MSBuild project file containing the projects and dependencies defined in the solution.
+    /// </remarks>
+    public sealed class SolutionFile
+    {
+        #region Solution specific constants
+
+        // An example of a project line looks like this:
+        //  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1\ClassLibrary1.csproj", "{05A5AD00-71B5-4612-AF2F-9EA9121C4111}"
+        private static readonly Lazy<Regex> s_crackProjectLine = new Lazy<Regex>(
+            () => new Regex
+                (
+                "^" // Beginning of line
+                + "Project\\(\"(?<PROJECTTYPEGUID>.*)\"\\)"
+                + "\\s*=\\s*" // Any amount of whitespace plus "=" plus any amount of whitespace
+                + "\"(?<PROJECTNAME>.*)\""
+                + "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+                + "\"(?<RELATIVEPATH>.*)\""
+                + "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+                + "\"(?<PROJECTGUID>.*)\""
+                + "$", // End-of-line
+                RegexOptions.Compiled
+                )
+            );
+
+        // An example of a property line looks like this:
+        //      AspNetCompiler.VirtualPath = "/webprecompile"
+        // Because website projects now include the target framework moniker as
+        // one of their properties, <PROPERTYVALUE> may now have '=' in it. 
+
+        private static readonly Lazy<Regex> s_crackPropertyLine = new Lazy<Regex>(
+            () => new Regex
+                (
+                "^" // Beginning of line
+                + "(?<PROPERTYNAME>[^=]*)"
+                + "\\s*=\\s*" // Any amount of whitespace plus "=" plus any amount of whitespace
+                + "(?<PROPERTYVALUE>.*)"
+                + "$", // End-of-line
+                RegexOptions.Compiled
+                )
+            );
+
+        internal const int slnFileMinUpgradableVersion = 7; // Minimum version for MSBuild to give a nice message
+        internal const int slnFileMinVersion = 9; // Minimum version for MSBuild to actually do anything useful
+        internal const int slnFileMaxVersion = VisualStudioConstants.CurrentVisualStudioSolutionFileVersion;
+
+        private const string vbProjectGuid = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
+        private const string csProjectGuid = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
+        private const string cpsProjectGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}";
+        private const string cpsCsProjectGuid = "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}";
+        private const string cpsVbProjectGuid = "{778DAE3C-4631-46EA-AA77-85C1314464D9}";
+        private const string vjProjectGuid = "{E6FDF86B-F3D1-11D4-8576-0002A516ECE8}";
+        private const string vcProjectGuid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
+        private const string fsProjectGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
+        private const string dbProjectGuid = "{C8D11400-126E-41CD-887F-60BD40844F9E}";
+        private const string wdProjectGuid = "{2CFEAB61-6A3B-4EB8-B523-560B4BEEF521}";
+        private const string webProjectGuid = "{E24C65DC-7377-472B-9ABA-BC803B73C61A}";
+        private const string solutionFolderGuid = "{2150E333-8FDC-42A3-9474-1A3956D46DE8}";
+
+        #endregion
+
+        #region Member data
+
+        private int _slnFileActualVersion = 0;               // The major version number of the .SLN file we're reading.
+        private string _solutionFile = null;                 // Could be absolute or relative path to the .SLN file.
+        private string _solutionFileDirectory = null;        // Absolute path the solution file
+        private bool _solutionContainsWebProjects = false;    // Does this SLN contain any web projects?
+        private bool _solutionContainsWebDeploymentProjects = false; // Does this SLN contain .wdproj projects?
+        private bool _parsingForConversionOnly = false;      // Are we parsing this solution to get project reference data during
+                                                             // conversion, or in preparation for actually building the solution?
+
+        // The list of projects in this SLN, keyed by the project GUID.
+        private Dictionary<string, ProjectInSolution> _projects = null;
+
+        // The list of projects in the SLN, in order of their appearance in the SLN.
+        private List<ProjectInSolution> _projectsInOrder = null;
+
+        // The list of solution configurations in the solution
+        private List<SolutionConfigurationInSolution> _solutionConfigurations;
+
+        // cached default configuration name for GetDefaultConfigurationName
+        private string _defaultConfigurationName;
+
+        // cached default platform name for GetDefaultPlatformName
+        private string _defaultPlatformName;
+
+        //List of warnings that occured while parsing solution
+        private ArrayList _solutionParserWarnings = null;
+
+        //List of comments that occured while parsing solution
+        private ArrayList _solutionParserComments = null;
+
+        // unit-testing only
+        private ArrayList _solutionParserErrorCodes = null;
+
+        // VisualStudionVersion specified in Dev12+ solutions
+        private Version _currentVisualStudioVersion = null;
+
+        private StreamReader _reader = null;
+        private int _currentLineNumber = 0;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal SolutionFile()
+        {
+            _solutionParserWarnings = new ArrayList();
+            _solutionParserErrorCodes = new ArrayList();
+            _solutionParserComments = new ArrayList();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// This property returns the list of warnings that were generated during solution parsing
+        /// </summary>
+        internal ArrayList SolutionParserWarnings
+        {
+            get
+            {
+                return _solutionParserWarnings;
+            }
+        }
+
+        /// <summary>
+        /// This property returns the list of comments that were generated during the solution parsing
+        /// </summary>
+        internal ArrayList SolutionParserComments
+        {
+            get
+            {
+                return _solutionParserComments;
+            }
+        }
+
+        /// <summary>
+        /// This property returns the list of error codes for warnings/errors that were generated during solution parsing. 
+        /// </summary>
+        internal ArrayList SolutionParserErrorCodes
+        {
+            get
+            {
+                return _solutionParserErrorCodes;
+            }
+        }
+
+        /// <summary>
+        /// Returns the actual major version of the parsed solution file
+        /// </summary>
+        internal int Version
+        {
+            get
+            {
+                return _slnFileActualVersion;
+            }
+        }
+
+        /// <summary>
+        /// Returns Visual Studio major version
+        /// </summary>
+        internal int VisualStudioVersion
+        {
+            get
+            {
+                if (_currentVisualStudioVersion != null)
+                {
+                    return _currentVisualStudioVersion.Major;
+                }
+                else
+                {
+                    return this.Version - 1;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the solution contains any web projects
+        /// </summary>
+        internal bool ContainsWebProjects
+        {
+            get
+            {
+                return _solutionContainsWebProjects;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the solution contains any .wdproj projects.  Used to determine
+        /// whether we need to load up any projects to examine dependencies. 
+        /// </summary>
+        internal bool ContainsWebDeploymentProjects
+        {
+            get
+            {
+                return _solutionContainsWebDeploymentProjects;
+            }
+        }
+
+        /// <summary>
+        /// All projects in this solution, in the order they appeared in the solution file
+        /// </summary>
+        public IReadOnlyList<ProjectInSolution> ProjectsInOrder
+        {
+            get
+            {
+                return _projectsInOrder.AsReadOnly();
+            }
+        }
+
+        /// <summary>
+        /// The collection of projects in this solution, accessible by their guids as a 
+        /// string in "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}" form
+        /// </summary>
+        public IReadOnlyDictionary<string, ProjectInSolution> ProjectsByGuid
+        {
+            get
+            {
+                return new ReadOnlyDictionary<string, ProjectInSolution>(_projects);
+            }
+        }
+
+        /// <summary>
+        /// This is the read/write accessor for the solution file which we will parse.  This
+        /// must be set before calling any other methods on this class.
+        /// </summary>
+        /// <value></value>
+        internal string FullPath
+        {
+            get
+            {
+                return _solutionFile;
+            }
+
+            set
+            {
+                // Should already be canonicalized to a full path
+                ErrorUtilities.VerifyThrowInternalRooted(value);
+                _solutionFile = value;
+            }
+        }
+
+        internal string SolutionFileDirectory
+        {
+            get
+            {
+                return _solutionFileDirectory;
+            }
+            // This setter is only used by the unit tests
+            set
+            {
+                _solutionFileDirectory = value;
+            }
+        }
+
+        /// <summary>
+        /// For unit-testing only.
+        /// </summary>
+        /// <value></value>
+        internal StreamReader SolutionReader
+        {
+            get
+            {
+                return _reader;
+            }
+
+            set
+            {
+                _reader = value;
+            }
+        }
+
+        /// <summary>
+        /// The list of all full solution configurations (configuration + platform) in this solution
+        /// </summary>
+        public IReadOnlyList<SolutionConfigurationInSolution> SolutionConfigurations
+        {
+            get
+            {
+                return _solutionConfigurations.AsReadOnly();
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// This method takes a path to a solution file, parses the projects and project dependencies
+        /// in the solution file, and creates internal data structures representing the projects within
+        /// the SLN.
+        /// </summary>
+        public static SolutionFile Parse(string solutionFile)
+        {
+            SolutionFile parser = new SolutionFile();
+            parser.FullPath = solutionFile;
+
+            parser.ParseSolutionFile();
+
+            return parser;
+        }
+
+        /// <summary>
+        /// Returns "true" if it's a project that's expected to be buildable, or false if it's 
+        /// not (e.g. a solution folder) 
+        /// </summary>
+        /// <param name="project">The project in the solution</param>
+        /// <returns>Whether the project is expected to be buildable</returns>
+        internal static bool IsBuildableProject(ProjectInSolution project)
+        {
+            return (project.ProjectType != SolutionProjectType.SolutionFolder && project.ProjectConfigurations.Count > 0);
+        }
+
+        /// <summary>
+        /// Given a solution file, parses the header and returns the major version numbers of the solution file
+        /// and the visual studio. 
+        /// Throws InvalidProjectFileException if the solution header is invalid, or if the version is less than 
+        /// our minimum version. 
+        /// </summary>
+        internal static void GetSolutionFileAndVisualStudioMajorVersions(string solutionFile, out int solutionVersion, out int visualStudioMajorVersion)
+        {
+            ErrorUtilities.VerifyThrow(!String.IsNullOrEmpty(solutionFile), "null solution file passed to GetSolutionFileMajorVersion!");
+            ErrorUtilities.VerifyThrowInternalRooted(solutionFile);
+
+            const string slnFileHeaderNoVersion = "Microsoft Visual Studio Solution File, Format Version ";
+            const string slnFileVSVLinePrefix = "VisualStudioVersion";
+            FileStream fileStream = null;
+            StreamReader reader = null;
+            bool validVersionFound = false;
+
+            solutionVersion = 0;
+            visualStudioMajorVersion = 0;
+
+            try
+            {
+                // Open the file
+                fileStream = File.OpenRead(solutionFile);
+                reader = new StreamReader(fileStream, Encoding.GetEncoding(0)); // HIGHCHAR: If solution files have no byte-order marks, then assume ANSI rather than ASCII.
+
+                // Read first 4 lines of the solution file. 
+                // The header is expected to be in line 1 or 2
+                // VisualStudioVersion is expected to be in line 3 or 4.
+                for (int i = 0; i < 4; i++)
+                {
+                    string line = reader.ReadLine();
+
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    if (line.Trim().StartsWith(slnFileHeaderNoVersion, StringComparison.Ordinal))
+                    {
+                        // Found it.  Validate the version.
+                        string fileVersionFromHeader = line.Substring(slnFileHeaderNoVersion.Length);
+
+                        Version version = null;
+                        if (!System.Version.TryParse(fileVersionFromHeader, out version))
+                        {
+                            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile
+                                (
+                                    false /* just throw the exception */,
+                                    "SubCategoryForSolutionParsingErrors",
+                                    new BuildEventFileInfo(solutionFile),
+                                    "SolutionParseVersionMismatchError",
+                                    slnFileMinUpgradableVersion,
+                                    slnFileMaxVersion
+                                );
+                        }
+
+                        solutionVersion = version.Major;
+
+                        // Validate against our min & max
+                        ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile
+                            (
+                                solutionVersion >= slnFileMinUpgradableVersion,
+                                "SubCategoryForSolutionParsingErrors",
+                                new BuildEventFileInfo(solutionFile),
+                                "SolutionParseVersionMismatchError",
+                                slnFileMinUpgradableVersion,
+                                slnFileMaxVersion
+                            );
+
+                        validVersionFound = true;
+                    }
+                    else if (line.Trim().StartsWith(slnFileVSVLinePrefix, StringComparison.Ordinal))
+                    {
+                        Version visualStudioVersion = ParseVisualStudioVersion(line);
+                        if (visualStudioVersion != null)
+                        {
+                            visualStudioMajorVersion = visualStudioVersion.Major;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                if (fileStream != null)
+                {
+                    fileStream.Dispose();
+                }
+
+                if (reader != null)
+                {
+                    reader.Dispose();
+                }
+            }
+
+            if (validVersionFound)
+            {
+                return;
+            }
+
+            // Didn't find the header in lines 1-4, so the solution file is invalid.
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile
+                (
+                    false /* just throw the exception */,
+                    "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(solutionFile),
+                    "SolutionParseNoHeaderError"
+                 );
+
+            return; /* UNREACHABLE */
+        }
+
+        /// <summary>
+        /// Adds a configuration to this solution
+        /// </summary>
+        internal void AddSolutionConfiguration(string configurationName, string platformName)
+        {
+            _solutionConfigurations.Add(new SolutionConfigurationInSolution(configurationName, platformName));
+        }
+
+        /// <summary>
+        /// Reads a line from the StreamReader, trimming leading and trailing whitespace.
+        /// </summary>
+        /// <returns></returns>
+        private string ReadLine()
+        {
+            ErrorUtilities.VerifyThrow(_reader != null, "ParseFileHeader(): reader is null!");
+
+            string line = _reader.ReadLine();
+            _currentLineNumber++;
+
+            if (line != null)
+            {
+                line = line.Trim();
+            }
+
+            return line;
+        }
+
+        /// <summary>
+        /// This method takes a path to a solution file, parses the projects and project dependencies
+        /// in the solution file, and creates internal data structures representing the projects within
+        /// the SLN.  Used for conversion, which means it allows situations that we refuse to actually build. 
+        /// </summary>
+        internal void ParseSolutionFileForConversion()
+        {
+            _parsingForConversionOnly = true;
+            ParseSolutionFile();
+        }
+
+        /// <summary>
+        /// This method takes a path to a solution file, parses the projects and project dependencies
+        /// in the solution file, and creates internal data structures representing the projects within
+        /// the SLN.
+        /// </summary>
+        internal void ParseSolutionFile()
+        {
+            ErrorUtilities.VerifyThrow((_solutionFile != null) && (_solutionFile.Length != 0), "ParseSolutionFile() got a null solution file!");
+            ErrorUtilities.VerifyThrowInternalRooted(_solutionFile);
+
+            FileStream fileStream = null;
+            _reader = null;
+
+            try
+            {
+                // Open the file
+                fileStream = File.OpenRead(_solutionFile);
+                // Store the directory of the file as the current directory may change while we are processes the file
+                _solutionFileDirectory = Path.GetDirectoryName(_solutionFile);
+                _reader = new StreamReader(fileStream, Encoding.GetEncoding(0)); // HIGHCHAR: If solution files have no byte-order marks, then assume ANSI rather than ASCII.
+                this.ParseSolution();
+            }
+            catch (Exception e)
+            {
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(!ExceptionUtilities.IsIoRelatedException(e), new BuildEventFileInfo(_solutionFile), "InvalidProjectFile", e.Message);
+                throw;
+            }
+            finally
+            {
+                if (fileStream != null)
+                {
+                    fileStream.Dispose();
+                }
+
+                if (_reader != null)
+                {
+                    _reader.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses the SLN file represented by the StreamReader in this.reader, and populates internal
+        /// data structures based on the SLN file contents.
+        /// </summary>
+        internal void ParseSolution()
+        {
+            _projects = new Dictionary<string, ProjectInSolution>(StringComparer.OrdinalIgnoreCase);
+            _projectsInOrder = new List<ProjectInSolution>();
+            _solutionContainsWebProjects = false;
+            _slnFileActualVersion = 0;
+            _currentLineNumber = 0;
+            _solutionConfigurations = new List<SolutionConfigurationInSolution>();
+            _defaultConfigurationName = null;
+            _defaultPlatformName = null;
+
+            // the raw list of project configurations in solution configurations, to be processed after it's fully read in.
+            Hashtable rawProjectConfigurationsEntries = null;
+
+            ParseFileHeader();
+
+            string str;
+            while ((str = ReadLine()) != null)
+            {
+                if (str.StartsWith("Project(", StringComparison.Ordinal))
+                {
+                    ParseProject(str);
+                }
+                else if (str.StartsWith("GlobalSection(NestedProjects)", StringComparison.Ordinal))
+                {
+                    ParseNestedProjects();
+                }
+                else if (str.StartsWith("GlobalSection(SolutionConfigurationPlatforms)", StringComparison.Ordinal))
+                {
+                    ParseSolutionConfigurations();
+                }
+                else if (str.StartsWith("GlobalSection(ProjectConfigurationPlatforms)", StringComparison.Ordinal))
+                {
+                    rawProjectConfigurationsEntries = ParseProjectConfigurations();
+                }
+                else if (str.StartsWith("VisualStudioVersion", StringComparison.Ordinal))
+                {
+                    _currentVisualStudioVersion = ParseVisualStudioVersion(str);
+                }
+                else
+                {
+                    // No other section types to process at this point, so just ignore the line
+                    // and continue.
+                }
+            }
+
+            if (rawProjectConfigurationsEntries != null)
+            {
+                ProcessProjectConfigurationSection(rawProjectConfigurationsEntries);
+            }
+
+            // Cache the unique name of each project, and check that we don't have any duplicates.
+            Hashtable projectsByUniqueName = new Hashtable(StringComparer.OrdinalIgnoreCase);
+
+            foreach (ProjectInSolution proj in _projectsInOrder)
+            {
+                // Find the unique name for the project.  This method also caches the unique name,
+                // so it doesn't have to be recomputed later.
+                string uniqueName = proj.GetUniqueProjectName();
+
+                if (proj.ProjectType == SolutionProjectType.WebProject)
+                {
+                    // Examine port information and determine if we need to disambiguate similarly-named projects with different ports.
+                    Uri uri;
+                    if (Uri.TryCreate(proj.RelativePath, UriKind.Absolute, out uri))
+                    {
+                        if (!uri.IsDefaultPort)
+                        {
+                            // If there are no other projects with the same name as this one, then we will keep this project's unique name, otherwise
+                            // we will create a new unique name with the port added.
+                            foreach (ProjectInSolution otherProj in _projectsInOrder)
+                            {
+                                if (Object.ReferenceEquals(proj, otherProj))
+                                {
+                                    continue;
+                                }
+
+                                if (String.Equals(otherProj.ProjectName, proj.ProjectName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    uniqueName = String.Format(CultureInfo.InvariantCulture, "{0}:{1}", uniqueName, uri.Port);
+                                    proj.UpdateUniqueProjectName(uniqueName);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Throw an error if there are any duplicates
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
+                    projectsByUniqueName[uniqueName] == null,
+                    "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath),
+                    "SolutionParseDuplicateProject",
+                    uniqueName);
+
+                // Update the hash table with this unique name
+                projectsByUniqueName[uniqueName] = proj;
+            }
+        } // ParseSolutionFile()
+
+        /// <summary>
+        /// This method searches the first two lines of the solution file opened by the specified
+        /// StreamReader for the solution file header.  An exception is thrown if it is not found.
+        /// 
+        /// The solution file header looks like this:
+        /// 
+        ///     Microsoft Visual Studio Solution File, Format Version 9.00
+        /// 
+        /// </summary>
+        private void ParseFileHeader()
+        {
+            ErrorUtilities.VerifyThrow(_reader != null, "ParseFileHeader(): reader is null!");
+
+            const string slnFileHeaderNoVersion = "Microsoft Visual Studio Solution File, Format Version ";
+
+            // Read the file header.  This can be on either of the first two lines.
+            for (int i = 1; i <= 2; i++)
+            {
+                string str = ReadLine();
+                if (str == null)
+                {
+                    break;
+                }
+
+                if (str.StartsWith(slnFileHeaderNoVersion, StringComparison.Ordinal))
+                {
+                    // Found it.  Validate the version.
+                    ValidateSolutionFileVersion(str.Substring(slnFileHeaderNoVersion.Length));
+                    return;
+                }
+            }
+
+            // Didn't find the header on either the first or second line, so the solution file
+            // is invalid.
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(false, "SubCategoryForSolutionParsingErrors",
+                new BuildEventFileInfo(FullPath), "SolutionParseNoHeaderError");
+        }
+
+        /// <summary>
+        /// This method parses the Visual Studio version in Dev 12 solution files
+        /// The version line looks like this:
+        /// 
+        /// VisualStudioVersion = 12.0.20311.0 VSPRO_PLATFORM
+        /// 
+        /// If such a line is found, the version is stored in this.currentVisualStudioVersion
+        /// </summary>
+        private static Version ParseVisualStudioVersion(string str)
+        {
+            Version currentVisualStudioVersion = null;
+            char[] delimiterChars = { ' ', '=' };
+            string[] words = str.Split(delimiterChars, StringSplitOptions.RemoveEmptyEntries);
+
+            if (words.Length >= 2)
+            {
+                string versionStr = words[1];
+                if (!System.Version.TryParse(versionStr, out currentVisualStudioVersion))
+                {
+                    currentVisualStudioVersion = null;
+                }
+            }
+
+            return currentVisualStudioVersion;
+        }
+        /// <summary>
+        /// This method extracts the whole part of the version number from the specified line
+        /// containing the solution file format header, and throws an exception if the version number
+        /// is outside of the valid range.
+        /// 
+        /// The solution file header looks like this:
+        /// 
+        ///     Microsoft Visual Studio Solution File, Format Version 9.00
+        /// 
+        /// </summary>
+        /// <param name="versionString"></param>
+        private void ValidateSolutionFileVersion(string versionString)
+        {
+            ErrorUtilities.VerifyThrow(versionString != null, "ValidateSolutionFileVersion() got a null line!");
+
+            Version version = null;
+
+            if (!System.Version.TryParse(versionString, out version))
+            {
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(false, "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseVersionMismatchError",
+                    slnFileMinUpgradableVersion, slnFileMaxVersion);
+            }
+
+            _slnFileActualVersion = version.Major;
+
+            // Validate against our min & max
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(
+                _slnFileActualVersion >= slnFileMinUpgradableVersion,
+                "SubCategoryForSolutionParsingErrors",
+                new BuildEventFileInfo(FullPath, _currentLineNumber, 0),
+                "SolutionParseVersionMismatchError",
+                slnFileMinUpgradableVersion, slnFileMaxVersion);
+            // If the solution file version is greater than the maximum one we will create a comment rather than warn
+            // as users such as blend opening a dev10 project cannot do anything about it.
+            if (_slnFileActualVersion > slnFileMaxVersion)
+            {
+                _solutionParserComments.Add(ResourceUtilities.FormatResourceString("UnrecognizedSolutionComment", _slnFileActualVersion));
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// This method processes a "Project" section in the solution file opened by the specified
+        /// StreamReader, and returns a populated ProjectInSolution instance, if successful.
+        /// An exception is thrown if the solution file is invalid.
+        ///
+        /// The format of the parts of a Project section that we care about is as follows:
+        ///
+        ///  Project("{Project type GUID}") = "Project name", "Relative path to project file", "{Project GUID}"
+        ///      ProjectSection(ProjectDependencies) = postProject
+        ///          {Parent project unique name} = {Parent project unique name}
+        ///          ...
+        ///      EndProjectSection
+        ///  EndProject
+        /// 
+        /// </summary>
+        /// <param name="firstLine"></param>
+        /// <returns></returns>
+        private void ParseProject(string firstLine)
+        {
+            ErrorUtilities.VerifyThrow((firstLine != null) && (firstLine.Length != 0), "ParseProject() got a null firstLine!");
+            ErrorUtilities.VerifyThrow(_reader != null, "ParseProject() got a null reader!");
+
+            ProjectInSolution proj = new ProjectInSolution(this);
+
+            // Extract the important information from the first line.
+            ParseFirstProjectLine(firstLine, proj);
+
+            // Search for project dependencies.  Keeping reading lines until we either 1.) reach
+            // the end of the file, 2.) see "ProjectSection(ProjectDependencies)" at the beginning
+            // of the line, or 3.) see "EndProject" at the beginning of the line.
+            string line;
+            while ((line = ReadLine()) != null)
+            {
+                // If we see an "EndProject", well ... that's the end of this project!
+                if (line == "EndProject")
+                {
+                    break;
+                }
+                else if (line.StartsWith("ProjectSection(ProjectDependencies)", StringComparison.Ordinal))
+                {
+                    // We have a ProjectDependencies section.  Each subsequent line should identify
+                    // a dependency.
+                    line = ReadLine();
+                    while ((line != null) && (!line.StartsWith("EndProjectSection", StringComparison.Ordinal)))
+                    {
+                        // This should be a dependency.  The GUID identifying the parent project should
+                        // be both the property name and the property value.
+                        Match match = s_crackPropertyLine.Value.Match(line);
+                        ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
+                            new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseProjectDepGuidError", proj.ProjectName);
+
+                        string parentGuid = match.Groups["PROPERTYNAME"].Value.Trim();
+                        proj.AddDependency(parentGuid);
+
+                        line = ReadLine();
+                    }
+                }
+#if FULL_SLN_PARSER
+                else if (line.StartsWith("ProjectSection(SolutionItems)", StringComparison.Ordinal))
+                {
+                    // We have a SolutionItems section.  Each subsequent line should identify
+                    // a solution item.
+                    line = ReadLine();
+                    while ((line != null) && (!line.StartsWith("EndProjectSection", StringComparison.Ordinal)))
+                    {
+                        proj.ProjectType = SolutionProjectType.SolutionFolder;
+
+                        // This should be a dependency.  The GUID identifying the parent project should
+                        // be both the property name and the property value.
+                        Match match = s_crackPropertyLine.Value.Match(line);
+                        if (match.Success)
+                        {
+                            string relativeFilePath = match.Groups["PROPERTYNAME"].Value.Trim();
+                            proj.AddFolderFile(relativeFilePath);
+                        }
+
+                        line = ReadLine();
+                    }
+                }
+#endif
+                else if (line.StartsWith("ProjectSection(WebsiteProperties)", StringComparison.Ordinal))
+                {
+                    // We have a WebsiteProperties section.  This section is present only in Venus
+                    // projects, and contains properties that we'll need in order to call the 
+                    // AspNetCompiler task.
+                    line = ReadLine();
+                    while ((line != null) && (!line.StartsWith("EndProjectSection", StringComparison.Ordinal)))
+                    {
+                        Match match = s_crackPropertyLine.Value.Match(line);
+                        ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
+                            new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseWebProjectPropertiesError", proj.ProjectName);
+
+                        string propertyName = match.Groups["PROPERTYNAME"].Value.Trim();
+                        string propertyValue = match.Groups["PROPERTYVALUE"].Value.Trim();
+
+                        ParseAspNetCompilerProperty(proj, propertyName, propertyValue);
+
+                        line = ReadLine();
+                    }
+                }
+            }
+
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(line != null, "SubCategoryForSolutionParsingErrors",
+                new BuildEventFileInfo(FullPath), "SolutionParseProjectEofError", proj.ProjectName);
+
+            // Add the project to the collection
+            AddProjectToSolution(proj);
+            // If the project is an etp project then parse the etp project file 
+            // to get the projects contained in it.
+            if (IsEtpProjectFile(proj.RelativePath))
+            {
+                ParseEtpProject(proj);
+            }
+        } // ParseProject()
+
+        /// <summary>
+        /// This method will parse a .etp project recursively and 
+        /// add all the projects found to projects and projectsInOrder
+        /// </summary>
+        /// <param name="etpProj">ETP Project</param>
+        internal void ParseEtpProject(ProjectInSolution etpProj)
+        {
+            XmlDocument etpProjectDocument = new XmlDocument();
+            // Get the full path to the .etp project file
+            string fullPathToEtpProj = Path.Combine(_solutionFileDirectory, etpProj.RelativePath);
+            string etpProjectRelativeDir = Path.GetDirectoryName(etpProj.RelativePath);
+            try
+            {
+                /****************************************************************************
+                * A Typical .etp project file will look like this
+                *<?xml version="1.0"?>
+                *<EFPROJECT>
+                *    <GENERAL>
+                *        <BANNER>Microsoft Visual Studio Application Template File</BANNER>
+                *        <VERSION>1.00</VERSION>
+                *        <Views>
+                *            <ProjectExplorer>
+                *                <File>ClassLibrary2\ClassLibrary2.csproj</File>
+                *            </ProjectExplorer>
+                *        </Views>
+                *        <References>
+                *            <Reference>
+                *                <FILE>ClassLibrary2\ClassLibrary2.csproj</FILE>
+                *                <GUIDPROJECTID>{73D0F4CE-D9D3-4E8B-81E4-B26FBF4CC2FE}</GUIDPROJECTID>
+                *            </Reference>
+                *        </References>
+                *    </GENERAL>
+                *</EFPROJECT>
+                **********************************************************************************/
+                // Make sure the XML reader ignores DTD processing
+                XmlReaderSettings readerSettings = new XmlReaderSettings();
+                readerSettings.DtdProcessing = DtdProcessing.Ignore;
+
+                // Load the .etp project file thru the XML reader
+                using (XmlReader xmlReader = XmlReader.Create(fullPathToEtpProj, readerSettings))
+                {
+                    etpProjectDocument.Load(xmlReader);
+                }
+
+                // We need to parse the .etp project file to get the names of projects contained
+                // in the .etp Project. The projects are listed under /EFPROJECT/GENERAL/References/Reference node in the .etp project file.
+                // The /EFPROJECT/GENERAL/Views/ProjectExplorer node will not necessarily contain 
+                // all the projects in the .etp project. Therefore, we need to look at 
+                // /EFPROJECT/GENERAL/References/Reference.
+                // Find the /EFPROJECT/GENERAL/References/Reference node
+                // Note that this is case sensitive
+                XmlNodeList referenceNodes = etpProjectDocument.DocumentElement.SelectNodes("/EFPROJECT/GENERAL/References/Reference");
+                // Do the right thing for each <REference> element
+                foreach (XmlNode referenceNode in referenceNodes)
+                {
+                    // Get the relative path to the project file
+                    string fileElementValue = referenceNode.SelectSingleNode("FILE").InnerText;
+                    // If <FILE>  element is not present under <Reference> then we don't do anything.
+                    if (fileElementValue != null)
+                    {
+                        // Create and populate a ProjectInSolution for the project
+                        ProjectInSolution proj = new ProjectInSolution(this);
+                        proj.RelativePath = Path.Combine(etpProjectRelativeDir, fileElementValue);
+
+                        // Verify the relative path specified in the .etp proj file
+                        ValidateProjectRelativePath(proj);
+                        proj.ProjectType = SolutionProjectType.EtpSubProject;
+                        proj.ProjectName = proj.RelativePath;
+                        XmlNode projGuidNode = referenceNode.SelectSingleNode("GUIDPROJECTID");
+                        if (projGuidNode != null)
+                        {
+                            proj.ProjectGuid = projGuidNode.InnerText;
+                        }
+                        // It is ok for a project to not have a guid inside an etp project.
+                        // If a solution file contains a project without a guid it fails to 
+                        // load in Everett. But if an etp project contains a project without 
+                        // a guid it loads well in Everett and p2p references to/from this project
+                        // are preserved. So we should make sure that we don’t error in this 
+                        // situation while upgrading.
+                        else
+                        {
+                            proj.ProjectGuid = String.Empty;
+                        }
+                        // Add the recently created proj to the collection of projects
+                        AddProjectToSolution(proj);
+                        // If the project is an etp project recurse
+                        if (IsEtpProjectFile(fileElementValue))
+                        {
+                            ParseEtpProject(proj);
+                        }
+                    }
+                }
+            }
+            // catch all sorts of exceptions - if we encounter any problems here, we just assume the .etp project file is not in the correct format
+
+            // handle security errors
+            catch (SecurityException e)
+            {
+                // Log a warning 
+                string errorCode, ignoredKeyword;
+                string warning = ResourceUtilities.FormatResourceString(out errorCode, out ignoredKeyword, "Shared.ProjectFileCouldNotBeLoaded",
+                    etpProj.RelativePath, e.Message);
+                _solutionParserWarnings.Add(warning);
+                _solutionParserErrorCodes.Add(errorCode);
+            }
+            // handle errors in path resolution
+            catch (NotSupportedException e)
+            {
+                // Log a warning 
+                string errorCode, ignoredKeyword;
+                string warning = ResourceUtilities.FormatResourceString(out errorCode, out ignoredKeyword, "Shared.ProjectFileCouldNotBeLoaded",
+                    etpProj.RelativePath, e.Message);
+                _solutionParserWarnings.Add(warning);
+                _solutionParserErrorCodes.Add(errorCode);
+            }
+            // handle errors in loading project file
+            catch (IOException e)
+            {
+                // Log a warning 
+                string errorCode, ignoredKeyword;
+                string warning = ResourceUtilities.FormatResourceString(out errorCode, out ignoredKeyword, "Shared.ProjectFileCouldNotBeLoaded",
+                    etpProj.RelativePath, e.Message);
+                _solutionParserWarnings.Add(warning);
+                _solutionParserErrorCodes.Add(errorCode);
+            }
+            // handle errors in loading project file
+            catch (UnauthorizedAccessException e)
+            {
+                // Log a warning 
+                string errorCode, ignoredKeyword;
+                string warning = ResourceUtilities.FormatResourceString(out errorCode, out ignoredKeyword, "Shared.ProjectFileCouldNotBeLoaded",
+                    etpProj.RelativePath, e.Message);
+                _solutionParserWarnings.Add(warning);
+                _solutionParserErrorCodes.Add(errorCode);
+            }
+            // handle XML parsing errors 
+            catch (XmlException e)
+            {
+                // Log a warning 
+                string errorCode, ignoredKeyword;
+                string warning = ResourceUtilities.FormatResourceString(out errorCode, out ignoredKeyword, "Shared.InvalidProjectFile",
+                   etpProj.RelativePath, e.Message);
+                _solutionParserWarnings.Add(warning);
+                _solutionParserErrorCodes.Add(errorCode);
+            }
+        }
+
+        /// <summary>
+        /// Adds a given project to the project collections of this class
+        /// </summary>
+        /// <param name="proj">proj</param>
+        private void AddProjectToSolution(ProjectInSolution proj)
+        {
+            if (!String.IsNullOrEmpty(proj.ProjectGuid))
+            {
+                _projects[proj.ProjectGuid] = proj;
+            }
+            _projectsInOrder.Add(proj);
+        }
+
+        /// <summary>
+        /// Checks whether a given project has a .etp extension.
+        /// </summary>
+        /// <param name="projectFile"></param>
+        private bool IsEtpProjectFile(string projectFile)
+        {
+            return projectFile.EndsWith(".etp", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Validate relative path of a project
+        /// </summary>
+        /// <param name="proj">proj</param>
+        private void ValidateProjectRelativePath(ProjectInSolution proj)
+        {
+            // Verify the relative path is not null
+            ErrorUtilities.VerifyThrow(proj.RelativePath != null, "Project relative path cannot be null.");
+
+            // Verify the relative path does not contain invalid characters
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj.RelativePath.IndexOfAny(Path.GetInvalidPathChars()) == -1,
+              "SubCategoryForSolutionParsingErrors",
+              new BuildEventFileInfo(FullPath, _currentLineNumber, 0),
+              "SolutionParseInvalidProjectFileNameCharacters",
+              proj.ProjectName, proj.RelativePath);
+
+            // Verify the relative path is not empty string
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj.RelativePath.Length > 0,
+                  "SubCategoryForSolutionParsingErrors",
+                  new BuildEventFileInfo(FullPath, _currentLineNumber, 0),
+                  "SolutionParseInvalidProjectFileNameEmpty",
+                  proj.ProjectName);
+        }
+
+        /// <summary>
+        /// Takes a property name / value that comes from the SLN file for a Venus project, and
+        /// stores it appropriately in our data structures.
+        /// </summary>
+        /// <param name="proj"></param>
+        /// <param name="propertyName"></param>
+        /// <param name="propertyValue"></param>
+        private void ParseAspNetCompilerProperty
+            (
+            ProjectInSolution proj,
+            string propertyName,
+            string propertyValue
+            )
+        {
+            // What we expect to find in the SLN file is something that looks like this:
+            //
+            // Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "c:\...\myfirstwebsite\", "..\..\..\..\..\..\rajeev\temp\websites\myfirstwebsite", "{956CC04E-FD59-49A9-9099-96888CB6F366}"
+            //     ProjectSection(WebsiteProperties) = preProject
+            //       TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
+            //       ProjectReferences = "{FD705688-88D1-4C22-9BFF-86235D89C2FC}|CSClassLibrary1.dll;{F0726D09-042B-4A7A-8A01-6BED2422BD5D}|VCClassLibrary1.dll;" 
+            //       Debug.AspNetCompiler.VirtualPath = "/publishfirst"
+            //       Debug.AspNetCompiler.PhysicalPath = "..\..\..\..\..\..\rajeev\temp\websites\myfirstwebsite\"
+            //       Debug.AspNetCompiler.TargetPath = "..\..\..\..\..\..\rajeev\temp\publishfirst\"
+            //       Debug.AspNetCompiler.ForceOverwrite = "true"
+            //       Debug.AspNetCompiler.Updateable = "true"
+            //       Debug.AspNetCompiler.Enabled = "true"
+            //       Debug.AspNetCompiler.Debug = "true"
+            //       Debug.AspNetCompiler.KeyFile = ""
+            //       Debug.AspNetCompiler.KeyContainer = ""
+            //       Debug.AspNetCompiler.DelaySign = "true"
+            //       Debug.AspNetCompiler.AllowPartiallyTrustedCallers = "true"
+            //       Debug.AspNetCompiler.FixedNames = "true"
+            //       Release.AspNetCompiler.VirtualPath = "/publishfirst"
+            //       Release.AspNetCompiler.PhysicalPath = "..\..\..\..\..\..\rajeev\temp\websites\myfirstwebsite\"
+            //       Release.AspNetCompiler.TargetPath = "..\..\..\..\..\..\rajeev\temp\publishfirst\"
+            //       Release.AspNetCompiler.ForceOverwrite = "true"
+            //       Release.AspNetCompiler.Updateable = "true"
+            //       Release.AspNetCompiler.Enabled = "true"
+            //       Release.AspNetCompiler.Debug = "false"
+            //       Release.AspNetCompiler.KeyFile = ""
+            //       Release.AspNetCompiler.KeyContainer = ""
+            //       Release.AspNetCompiler.DelaySign = "true"
+            //       Release.AspNetCompiler.AllowPartiallyTrustedCallers = "true"
+            //       Release.AspNetCompiler.FixedNames = "true"
+            //     EndProjectSection
+            // EndProject
+            //
+            // This method is responsible for parsing each of the lines within the "WebsiteProperties" section.
+            // The first component of each property name is actually the configuration for which that
+            // property applies.
+
+            int indexOfFirstDot = propertyName.IndexOf('.');
+            if (indexOfFirstDot != -1)
+            {
+                // The portion before the first dot is the configuration name.
+                string configurationName = propertyName.Substring(0, indexOfFirstDot);
+
+                // The rest of it is the actual property name.
+                string aspNetPropertyName = ((propertyName.Length - indexOfFirstDot) > 0) ? propertyName.Substring(indexOfFirstDot + 1, propertyName.Length - indexOfFirstDot - 1) : "";
+
+                // And the part after the <equals> sign is the property value (which was parsed out for us prior
+                // to calling this method).
+                propertyValue = TrimQuotes(propertyValue);
+
+                // Grab the parameters for this specific configuration if they exist.
+                object aspNetCompilerParametersObject = proj.AspNetConfigurations[configurationName];
+                AspNetCompilerParameters aspNetCompilerParameters;
+
+                if (aspNetCompilerParametersObject == null)
+                {
+                    // If it didn't exist, create a new one.
+                    aspNetCompilerParameters = new AspNetCompilerParameters();
+                    aspNetCompilerParameters.aspNetVirtualPath = String.Empty;
+                    aspNetCompilerParameters.aspNetPhysicalPath = String.Empty;
+                    aspNetCompilerParameters.aspNetTargetPath = String.Empty;
+                    aspNetCompilerParameters.aspNetForce = String.Empty;
+                    aspNetCompilerParameters.aspNetUpdateable = String.Empty;
+                    aspNetCompilerParameters.aspNetDebug = String.Empty;
+                    aspNetCompilerParameters.aspNetKeyFile = String.Empty;
+                    aspNetCompilerParameters.aspNetKeyContainer = String.Empty;
+                    aspNetCompilerParameters.aspNetDelaySign = String.Empty;
+                    aspNetCompilerParameters.aspNetAPTCA = String.Empty;
+                    aspNetCompilerParameters.aspNetFixedNames = String.Empty;
+                }
+                else
+                {
+                    // Otherwise just unbox it.
+                    aspNetCompilerParameters = (AspNetCompilerParameters)aspNetCompilerParametersObject;
+                }
+
+                // Update the appropriate field within the parameters struct.
+                if (aspNetPropertyName == "AspNetCompiler.VirtualPath")
+                {
+                    aspNetCompilerParameters.aspNetVirtualPath = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.PhysicalPath")
+                {
+                    aspNetCompilerParameters.aspNetPhysicalPath = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.TargetPath")
+                {
+                    aspNetCompilerParameters.aspNetTargetPath = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.ForceOverwrite")
+                {
+                    aspNetCompilerParameters.aspNetForce = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.Updateable")
+                {
+                    aspNetCompilerParameters.aspNetUpdateable = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.Debug")
+                {
+                    aspNetCompilerParameters.aspNetDebug = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.KeyFile")
+                {
+                    aspNetCompilerParameters.aspNetKeyFile = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.KeyContainer")
+                {
+                    aspNetCompilerParameters.aspNetKeyContainer = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.DelaySign")
+                {
+                    aspNetCompilerParameters.aspNetDelaySign = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.AllowPartiallyTrustedCallers")
+                {
+                    aspNetCompilerParameters.aspNetAPTCA = propertyValue;
+                }
+                else if (aspNetPropertyName == "AspNetCompiler.FixedNames")
+                {
+                    aspNetCompilerParameters.aspNetFixedNames = propertyValue;
+                }
+
+                // Store the updated parameters struct back into the hashtable by configuration name.
+                proj.AspNetConfigurations[configurationName] = aspNetCompilerParameters;
+            }
+            else
+            {
+                // ProjectReferences = "{FD705688-88D1-4C22-9BFF-86235D89C2FC}|CSClassLibrary1.dll;{F0726D09-042B-4A7A-8A01-6BED2422BD5D}|VCClassLibrary1.dll;" 
+                if (string.Compare(propertyName, "ProjectReferences", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    string[] projectReferenceEntries = propertyValue.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (string projectReferenceEntry in projectReferenceEntries)
+                    {
+                        int indexOfBar = projectReferenceEntry.IndexOf('|');
+
+                        // indexOfBar could be -1 if we had semicolons in the file names, so skip entries that 
+                        // don't contain a guid. File names may not contain the '|' character
+                        if (indexOfBar != -1)
+                        {
+                            int indexOfOpeningBrace = projectReferenceEntry.IndexOf('{');
+                            if (indexOfOpeningBrace != -1)
+                            {
+                                int indexOfClosingBrace = projectReferenceEntry.IndexOf('}', indexOfOpeningBrace);
+                                if (indexOfClosingBrace != -1)
+                                {
+                                    string referencedProjectGuid = projectReferenceEntry.Substring(indexOfOpeningBrace,
+                                        indexOfClosingBrace - indexOfOpeningBrace + 1);
+
+                                    proj.AddDependency(referencedProjectGuid);
+                                    proj.ProjectReferences.Add(referencedProjectGuid);
+                                }
+                            }
+                        }
+                    }
+                }
+                else if (String.Compare(propertyName, "TargetFrameworkMoniker", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    //Website project need to back support 3.5 msbuild parser for the Blend (it is not move to .Net4.0 yet.)
+                    //However, 3.5 version of Solution parser can't handle a equal sign in the value.  
+                    //The "=" in targetframeworkMoniker was escaped to "%3D" for Orcas
+                    string targetFrameworkMoniker = TrimQuotes(propertyValue);
+                    proj.TargetFrameworkMoniker = Microsoft.Build.Shared.EscapingUtilities.UnescapeAll(targetFrameworkMoniker);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Strips a single pair of leading/trailing double-quotes from a string.
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        private string TrimQuotes
+            (
+            string property
+            )
+        {
+            // If the incoming string starts and ends with a double-quote, strip the double-quotes.
+            if ((property != null) && (property.Length > 0) && (property[0] == '"') && (property[property.Length - 1] == '"'))
+            {
+                return property.Substring(1, property.Length - 2);
+            }
+            else
+            {
+                return property;
+            }
+        }
+
+        /// <summary>
+        /// Parse the first line of a Project section of a solution file. This line should look like:
+        ///
+        ///  Project("{Project type GUID}") = "Project name", "Relative path to project file", "{Project GUID}"
+        /// 
+        /// </summary>
+        /// <param name="firstLine"></param>
+        /// <param name="proj"></param>
+        internal void ParseFirstProjectLine
+        (
+            string firstLine,
+            ProjectInSolution proj
+        )
+        {
+            Match match = s_crackProjectLine.Value.Match(firstLine);
+            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
+                new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseProjectError");
+
+            string projectTypeGuid = match.Groups["PROJECTTYPEGUID"].Value.Trim();
+            proj.ProjectName = match.Groups["PROJECTNAME"].Value.Trim();
+            proj.RelativePath = match.Groups["RELATIVEPATH"].Value.Trim();
+            proj.ProjectGuid = match.Groups["PROJECTGUID"].Value.Trim();
+
+            // If the project name is empty (as in some bad solutions) set it to some generated generic value.  
+            // This allows us to at least generate reasonable target names etc. instead of crashing. 
+            if (String.IsNullOrEmpty(proj.ProjectName))
+            {
+                proj.ProjectName = "EmptyProjectName." + Guid.NewGuid();
+            }
+
+            // Validate project relative path
+            ValidateProjectRelativePath(proj);
+
+            // Figure out what type of project this is.
+            if ((String.Compare(projectTypeGuid, vbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, csProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, cpsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, cpsCsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, cpsVbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, dbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+                (String.Compare(projectTypeGuid, vjProjectGuid, StringComparison.OrdinalIgnoreCase) == 0))
+            {
+                proj.ProjectType = SolutionProjectType.KnownToBeMSBuildFormat;
+            }
+            else if (String.Compare(projectTypeGuid, solutionFolderGuid, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                proj.ProjectType = SolutionProjectType.SolutionFolder;
+            }
+            // MSBuild format VC projects have the same project type guid as old style VC projects.
+            // If it's not an old-style VC project, we'll assume it's MSBuild format
+            else if (String.Compare(projectTypeGuid, vcProjectGuid, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                if (String.Equals(proj.Extension, ".vcproj", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!_parsingForConversionOnly)
+                    {
+                        ProjectFileErrorUtilities.ThrowInvalidProjectFile(new BuildEventFileInfo(FullPath), "ProjectUpgradeNeededToVcxProj", proj.RelativePath);
+                    }
+                    // otherwise, we're parsing this solution file because we want the P2P information during 
+                    // conversion, and it's perfectly valid for an unconverted solution file to still contain .vcprojs
+                }
+                else
+                {
+                    proj.ProjectType = SolutionProjectType.KnownToBeMSBuildFormat;
+                }
+            }
+            else if (String.Compare(projectTypeGuid, webProjectGuid, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                proj.ProjectType = SolutionProjectType.WebProject;
+                _solutionContainsWebProjects = true;
+            }
+            else if (String.Compare(projectTypeGuid, wdProjectGuid, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                proj.ProjectType = SolutionProjectType.WebDeploymentProject;
+                _solutionContainsWebDeploymentProjects = true;
+            }
+            else
+            {
+                proj.ProjectType = SolutionProjectType.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// Read nested projects section.
+        /// This is required to find a unique name for each project's target
+        /// </summary>
+        internal void ParseNestedProjects()
+        {
+            string str;
+
+            do
+            {
+                str = ReadLine();
+                if ((str == null) || (str == "EndGlobalSection"))
+                {
+                    break;
+                }
+
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
+                }
+
+                Match match = s_crackPropertyLine.Value.Match(str);
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseNestedProjectError");
+
+                string projectGuid = match.Groups["PROPERTYNAME"].Value.Trim();
+                string parentProjectGuid = match.Groups["PROPERTYVALUE"].Value.Trim();
+
+                ProjectInSolution proj;
+                if (!_projects.TryGetValue(projectGuid, out proj))
+                {
+                    ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(proj != null, "SubCategoryForSolutionParsingErrors",
+                       new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseNestedProjectUndefinedError", projectGuid, parentProjectGuid);
+                }
+
+                proj.ParentProjectGuid = parentProjectGuid;
+            } while (true);
+        }
+
+        /// <summary>
+        /// Read solution configuration section. 
+        /// </summary>
+        /// <remarks>
+        /// A sample section:
+        /// 
+        /// GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        ///     Debug|Any CPU = Debug|Any CPU
+        ///     Release|Any CPU = Release|Any CPU
+        /// EndGlobalSection
+        /// </remarks>
+        internal void ParseSolutionConfigurations()
+        {
+            string str;
+            char[] nameValueSeparators = new char[] { '=' };
+            char[] configPlatformSeparators = new char[] { SolutionConfigurationInSolution.ConfigurationPlatformSeparator };
+
+            do
+            {
+                str = ReadLine();
+
+                if ((str == null) || (str == "EndGlobalSection"))
+                {
+                    break;
+                }
+
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
+                }
+
+                string[] configurationNames = str.Split(nameValueSeparators);
+
+                // There should be exactly one '=' character, separating two names. 
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(configurationNames.Length == 2, "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidSolutionConfigurationEntry", str);
+
+                string fullConfigurationName = configurationNames[0].Trim();
+
+                //Fixing bug 555577: Solution file can have description information, in which case we ignore.
+                if (0 == String.Compare(fullConfigurationName, "DESCRIPTION", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Both names must be identical
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(fullConfigurationName == configurationNames[1].Trim(), "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidSolutionConfigurationEntry", str);
+
+                string[] configurationPlatformParts = fullConfigurationName.Split(configPlatformSeparators);
+
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(configurationPlatformParts.Length == 2, "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidSolutionConfigurationEntry", str);
+
+                _solutionConfigurations.Add(new SolutionConfigurationInSolution(configurationPlatformParts[0], configurationPlatformParts[1]));
+            } while (true);
+        }
+
+        /// <summary>
+        /// Read project configurations in solution configurations section.
+        /// </summary>
+        /// <remarks>
+        /// A sample (incomplete) section:
+        /// 
+        /// GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        /// 	{6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        /// 	{6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        /// 	{6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.ActiveCfg = Release|Any CPU
+        /// 	{6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Mixed Platforms.Build.0 = Release|Any CPU
+        /// 	{6185CC21-BE89-448A-B3C0-D1C27112E595}.Debug|Win32.ActiveCfg = Debug|Any CPU
+        /// 	{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Any CPU.ActiveCfg = Release|Win32
+        /// 	{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+        /// 	{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Mixed Platforms.Build.0 = Release|Win32
+        /// 	{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Win32.ActiveCfg = Release|Win32
+        /// 	{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Win32.Build.0 = Release|Win32
+        /// EndGlobalSection
+        /// </remarks>
+        /// <returns>An unprocessed hashtable of entries in this section</returns>
+        internal Hashtable ParseProjectConfigurations()
+        {
+            Hashtable rawProjectConfigurationsEntries = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            string str;
+
+            do
+            {
+                str = ReadLine();
+
+                if ((str == null) || (str == "EndGlobalSection"))
+                {
+                    break;
+                }
+
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
+                }
+
+                string[] nameValue = str.Split(new char[] { '=' });
+
+                // There should be exactly one '=' character, separating the name and value. 
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(nameValue.Length == 2, "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseInvalidProjectSolutionConfigurationEntry", str);
+
+                rawProjectConfigurationsEntries[nameValue[0].Trim()] = nameValue[1].Trim();
+            } while (true);
+
+            return rawProjectConfigurationsEntries;
+        }
+
+        /// <summary>
+        /// Read the project configuration information for every project in the solution, using pre-cached 
+        /// solution section data. 
+        /// </summary>
+        /// <param name="rawProjectConfigurationsEntries">Cached data from the project configuration section</param>
+        internal void ProcessProjectConfigurationSection(Hashtable rawProjectConfigurationsEntries)
+        {
+            // Instead of parsing the data line by line, we parse it project by project, constructing the 
+            // entry name (e.g. "{A6F99D27-47B9-4EA4-BFC9-25157CBDC281}.Release|Any CPU.ActiveCfg") and retrieving its 
+            // value from the raw data. The reason for this is that the IDE does it this way, and as the result
+            // the '.' character is allowed in configuration names although it technically separates different
+            // parts of the entry name string. This could lead to ambiguous results if we tried to parse 
+            // the entry name instead of constructing it and looking it up. Although it's pretty unlikely that
+            // this would ever be a problem, it's safer to do it the same way VS IDE does it.
+            char[] configPlatformSeparators = new char[] { SolutionConfigurationInSolution.ConfigurationPlatformSeparator };
+
+            foreach (ProjectInSolution project in _projectsInOrder)
+            {
+                // Solution folders don't have configurations
+                if (project.ProjectType != SolutionProjectType.SolutionFolder)
+                {
+                    foreach (SolutionConfigurationInSolution solutionConfiguration in _solutionConfigurations)
+                    {
+                        // The "ActiveCfg" entry defines the active project configuration in the given solution configuration
+                        // This entry must be present for every possible solution configuration/project combination.
+                        string entryNameActiveConfig = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.ActiveCfg",
+                            project.ProjectGuid, solutionConfiguration.FullName);
+
+                        // The "Build.0" entry tells us whether to build the project configuration in the given solution configuration.
+                        // Technically, it specifies a configuration name of its own which seems to be a remnant of an initial, 
+                        // more flexible design of solution configurations (as well as the '.0' suffix - no higher values are ever used). 
+                        // The configuration name is not used, and the whole entry means "build the project configuration" 
+                        // if it's present in the solution file, and "don't build" if it's not.
+                        string entryNameBuild = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.Build.0",
+                            project.ProjectGuid, solutionConfiguration.FullName);
+
+                        if (rawProjectConfigurationsEntries.ContainsKey(entryNameActiveConfig))
+                        {
+                            string[] configurationPlatformParts = ((string)(rawProjectConfigurationsEntries[entryNameActiveConfig])).Split(configPlatformSeparators);
+
+                            // Project configuration may not necessarily contain the platform part. Some project support only the configuration part.
+                            ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(configurationPlatformParts.Length <= 2, "SubCategoryForSolutionParsingErrors",
+                                new BuildEventFileInfo(FullPath), "SolutionParseInvalidProjectSolutionConfigurationEntry",
+                                string.Format(CultureInfo.InvariantCulture, "{0} = {1}", entryNameActiveConfig, rawProjectConfigurationsEntries[entryNameActiveConfig]));
+
+                            ProjectConfigurationInSolution projectConfiguration = new ProjectConfigurationInSolution(
+                                configurationPlatformParts[0],
+                                (configurationPlatformParts.Length > 1) ? configurationPlatformParts[1] : string.Empty,
+                                rawProjectConfigurationsEntries.ContainsKey(entryNameBuild)
+                            );
+
+                            project.SetProjectConfiguration(solutionConfiguration.FullName, projectConfiguration);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the default configuration name for this solution. Usually it's Debug, unless it's not present
+        /// in which case it's the first configuration name we find.
+        /// </summary>
+        public string GetDefaultConfigurationName()
+        {
+            // Have we done this already? Return the cached name
+            if (_defaultConfigurationName != null)
+            {
+                return _defaultConfigurationName;
+            }
+
+            _defaultConfigurationName = string.Empty;
+
+            // Pick the Debug configuration as default if present
+            foreach (SolutionConfigurationInSolution solutionConfiguration in this.SolutionConfigurations)
+            {
+                if (string.Compare(solutionConfiguration.ConfigurationName, "Debug", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    _defaultConfigurationName = solutionConfiguration.ConfigurationName;
+                    break;
+                }
+            }
+
+            // Failing that, just pick the first configuration name as default
+            if ((_defaultConfigurationName.Length == 0) && (this.SolutionConfigurations.Count > 0))
+            {
+                _defaultConfigurationName = this.SolutionConfigurations[0].ConfigurationName;
+            }
+
+            return _defaultConfigurationName;
+        }
+
+        /// <summary>
+        /// Gets the default platform name for this solution. Usually it's Mixed Platforms, unless it's not present
+        /// in which case it's the first platform name we find.
+        /// </summary>
+        public string GetDefaultPlatformName()
+        {
+            // Have we done this already? Return the cached name
+            if (_defaultPlatformName != null)
+            {
+                return _defaultPlatformName;
+            }
+
+            _defaultPlatformName = string.Empty;
+
+            // Pick the Mixed Platforms platform as default if present
+            foreach (SolutionConfigurationInSolution solutionConfiguration in this.SolutionConfigurations)
+            {
+                if (string.Compare(solutionConfiguration.PlatformName, "Mixed Platforms", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    _defaultPlatformName = solutionConfiguration.PlatformName;
+                    break;
+                }
+                // We would like this to be chosen if Mixed platforms does not exist.
+                else if (string.Compare(solutionConfiguration.PlatformName, "Any CPU", StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    _defaultPlatformName = solutionConfiguration.PlatformName;
+                }
+            }
+
+            // Failing that, just pick the first platform name as default
+            if ((_defaultPlatformName.Length == 0) && (this.SolutionConfigurations.Count > 0))
+            {
+                _defaultPlatformName = this.SolutionConfigurations[0].PlatformName;
+            }
+
+            return _defaultPlatformName;
+        }
+
+        /// <summary>
+        /// This method takes a string representing one of the project's unique names (guid), and
+        /// returns the corresponding "friendly" name for this project.
+        /// </summary>
+        /// <param name="projectGuid"></param>
+        /// <returns></returns>
+        internal string GetProjectUniqueNameByGuid(string projectGuid)
+        {
+            ProjectInSolution proj;
+            if (_projects.TryGetValue(projectGuid, out proj))
+            {
+                return proj.GetUniqueProjectName();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// This method takes a string representing one of the project's unique names (guid), and
+        /// returns the corresponding relative path to this project.
+        /// </summary>
+        /// <param name="projectGuid"></param>
+        /// <returns></returns>
+        internal string GetProjectRelativePathByGuid(string projectGuid)
+        {
+            ProjectInSolution proj;
+            if (_projects.TryGetValue(projectGuid, out proj))
+            {
+                return proj.RelativePath;
+            }
+
+            return null;
+        }
+
+#endregion
+    } // class SolutionParser
+} // namespace Microsoft.Build.Construction

--- a/src/Sln/Original/VisualStudioConstants.cs
+++ b/src/Sln/Original/VisualStudioConstants.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Shared Visual Studio related constants.</summary>
+//-----------------------------------------------------------------------
+
+//source: https://raw.githubusercontent.com/Microsoft/msbuild/master/src/Shared/VisualStudioConstants.cs
+
+using System;
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// Shared Visual Studio related constants
+    /// </summary>
+    internal static class VisualStudioConstants
+    {
+        /// <summary>
+        /// This is the version number of the most recent solution file format
+        /// we will read. It will be the version number used in solution files
+        /// by the latest version of Visual Studio.
+        /// </summary>
+        internal const int CurrentVisualStudioSolutionFileVersion = 12; // VS11
+
+        /// <summary>
+        /// This is the version number of the latest version of Visual Studio.
+        /// </summary>
+        /// <remarks>
+        /// We use it for the version of the VC PIA we try to load and to find
+        /// Visual Studio registry hive that we use to find where vcbuild.exe might be.
+        /// </remarks>
+        internal const string CurrentVisualStudioVersion = "10.0";
+    }
+}

--- a/src/Sln/Sln.csproj
+++ b/src/Sln/Sln.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Sln/Sln.csproj
+++ b/src/Sln/Sln.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <Description>Parse sln files</Description>
   </PropertyGroup>
 
 </Project>

--- a/src/Sln/Sln.csproj
+++ b/src/Sln/Sln.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <Description>Parse sln files</Description>
+    <DefineConstants>FULL_SLN_PARSER;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
sln parser sources from https://github.com/microsoft/msbuild with minor tweak (solution folder files, fix f# bug)

code has microsoft.msbuild.* namespace because i stealed the code from https://github.com/microsoft/msbuild repo, but DOESNT use msbuild automation and has zero deps

TODO

- [ ] package
- [ ] add submodules/subtree to sync files from `microsoft/msbuild`
      - or contrib back changes to `microsoft/msbuild` to avoid differences, if can be done short term

