### PR TITLE
add gather info about installed .net framework

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
 
     <RepoRootDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\.."))</RepoRootDir>
     <NupkgsDir>$(RepoRootDir)/bin/nupkg</NupkgsDir>
-    <Version Condition=" '$(Version)' == '' ">0.8.0$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">0.9.0$(VersionSuffix)</Version>
     <MonoOrEmpty Condition=" '$(OS)' != 'Windows_NT' ">mono </MonoOrEmpty>
   </PropertyGroup>
 </Project>

--- a/src/Dotnet.ProjInfo/Dotnet.ProjInfo.fsproj
+++ b/src/Dotnet.ProjInfo/Dotnet.ProjInfo.fsproj
@@ -5,6 +5,10 @@
     <Description>Get msbuild info</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="Resources.fs" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <!-- old fsproj is not supported on netstandard1.6 -->
     <Compile Include="ExternalFSharp\MissingApi.fs" />
@@ -17,9 +21,6 @@
 
   <ItemGroup>
     <Compile Include="..\dotnet-proj-info\Inspect.fs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <Compile Include="NETFrameworkInfoFromMSBuild.fs" />
 
     <EmbeddedResource Include="Resources\EnvironmentInfo.proj" />

--- a/src/Dotnet.ProjInfo/Dotnet.ProjInfo.fsproj
+++ b/src/Dotnet.ProjInfo/Dotnet.ProjInfo.fsproj
@@ -19,6 +19,12 @@
     <Compile Include="..\dotnet-proj-info\Inspect.fs" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
+    <Compile Include="NETFrameworkInfoFromMSBuild.fs" />
+
+    <EmbeddedResource Include="Resources\EnvironmentInfo.proj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Condition=" '$(TargetFramework)' == 'netstandard1.6' " Version="4.1.*" />
     <PackageReference Include="FSharp.Core" Condition=" '$(TargetFramework)' == 'net45' " Version="4.0.0.1" />

--- a/src/Dotnet.ProjInfo/ExternalFSharp/FscConfig.fs
+++ b/src/Dotnet.ProjInfo/ExternalFSharp/FscConfig.fs
@@ -100,24 +100,9 @@ let inline getResponseFileFromTask props (fsc: ^a) =
     responseFileText.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries)
     |> List.ofArray
 
-type internal Dummy() = inherit Object()
-
-open System.Reflection
-
-let getResourceFileAsString resourceName =
-    let assembly = typeof<Dummy>.GetTypeInfo().Assembly
-
-    use stream = assembly.GetManifestResourceStream(resourceName)
-    match stream with
-    | null -> failwithf "Resource '%s' not found in assembly '%s'" resourceName (assembly.FullName)
-    | stream ->
-        use reader = new IO.StreamReader(stream)
-
-        reader.ReadToEnd()
-
 let getFscTaskProperties () =
 
-    let msFsharpTargetText = getResourceFileAsString "Microsoft.FSharp.Targets"
+    let msFsharpTargetText = Resources.getResourceFileAsString "Microsoft.FSharp.Targets"
 
     let doc =
         try

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -9,10 +9,6 @@ open Dotnet.ProjInfo.Inspect
 
 open Dotnet.ProjInfo.Inspect.MSBuild
 
-type private FrameworkInfoFromMsbuild = {
-    ReferencePath: string list
-  }
-
 let createEnvInfoProj () =
   let createTempDir () =
       let tempPath = Path.GetTempFileName()

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -1,0 +1,66 @@
+module Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild
+
+open System
+open System.IO
+
+open Dotnet.ProjInfo.Inspect.MSBuild
+
+type private FrameworkInfoFromMsbuild = {
+    ReferencePath: string list
+  }
+
+let createEnvInfoProj () =
+  let createTempDir () =
+      let tempPath = Path.GetTempFileName()
+      File.Delete(tempPath)
+      Directory.CreateDirectory(tempPath).FullName
+
+  let tempDir = createTempDir ()
+  let proj = Path.Combine(tempDir, "EnvironmentInfo.proj")
+  let projContent = FakeMsbuildTasks.getResourceFileAsString "EnvironmentInfo.proj"
+  File.WriteAllText(proj, projContent)
+  proj
+
+let getReferencePaths props =
+
+    let template =
+        """
+  <ItemGroup>
+        """
+      + (
+          props
+          |> List.map (sprintf """<Reference Include="%s" />""")
+          |> String.concat (System.Environment.NewLine) )
+      +
+        """
+  </ItemGroup>
+
+  <Target Name="_GetFsxScriptReferences" DependsOnTargets="ResolveAssemblyReferences">
+    <Message Text="ReferencePath=%(ReferencePath.Identity)" Importance="High" />
+    <WriteLinesToFile
+            Condition=" '$(_GetFsxScriptReferences_OutFile)' != '' "
+            File="$(_GetFsxScriptReferences_OutFile)"
+            Lines="@(ReferencePath -> 'ReferencePath=%(Identity)')"
+            Overwrite="true"
+            Encoding="UTF-8"/>
+            
+    <!-- WriteLinesToFile doesnt create the file if @(ReferencePath) is empty -->
+    <Touch
+        Condition=" '$(_GetFsxScriptReferences_OutFile)' != '' "
+        Files="$(_GetFsxScriptReferences_OutFile)"
+        AlwaysCreate="True" />
+  </Target>
+        """.Trim()
+    let outFile = Inspect.getNewTempFilePath "fsxScriptReferences.txt"
+    let args =
+        [ Target "_GetFsxScriptReferences"
+          Property ("_GetFsxScriptReferences_OutFile", outFile) ]
+
+    // { TargetFrameworkRootPath = lines |> List.tryPick (chooseByPrefix "TargetFrameworkRootPath=")
+    //   FrameworkPathOverride = lines |> List.tryPick (chooseByPrefix "FrameworkPathOverride=")
+    //   ReferencePath = lines |> List.choose (chooseByPrefix "ReferencePath=") }
+
+    template, args, (fun () -> outFile
+                               |> Inspect.bindSkipped Inspect.parsePropertiesOut
+                               |> Result.map (List.map snd >> Inspect.GetResult.ResolvedNETRefs))
+

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -17,7 +17,7 @@ let createEnvInfoProj () =
 
   let tempDir = createTempDir ()
   let proj = Path.Combine(tempDir, "EnvironmentInfo.proj")
-  let projContent = FakeMsbuildTasks.getResourceFileAsString "EnvironmentInfo.proj"
+  let projContent = Resources.getResourceFileAsString "EnvironmentInfo.proj"
   File.WriteAllText(proj, projContent)
   proj
 

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -3,6 +3,10 @@ module Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild
 open System
 open System.IO
 
+#if NET45
+open Dotnet.ProjInfo.Inspect
+#endif
+
 open Dotnet.ProjInfo.Inspect.MSBuild
 
 type private FrameworkInfoFromMsbuild = {

--- a/src/Dotnet.ProjInfo/Resources.fs
+++ b/src/Dotnet.ProjInfo/Resources.fs
@@ -1,0 +1,18 @@
+module Dotnet.ProjInfo.Resources
+
+open System
+
+type internal Dummy() = inherit Object()
+
+open System.Reflection
+
+let getResourceFileAsString resourceName =
+    let assembly = typeof<Dummy>.GetTypeInfo().Assembly
+
+    use stream = assembly.GetManifestResourceStream(resourceName)
+    match stream with
+    | null -> failwithf "Resource '%s' not found in assembly '%s'" resourceName (assembly.FullName)
+    | stream ->
+        use reader = new IO.StreamReader(stream)
+
+        reader.ReadToEnd()

--- a/src/Dotnet.ProjInfo/Resources/EnvironmentInfo.proj
+++ b/src/Dotnet.ProjInfo/Resources/EnvironmentInfo.proj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+</Project>

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -111,7 +111,7 @@ type GetResult =
      | Properties of (string * string) list
      | ResolvedNETRefs of string list
      | InstalledNETFw of string list
-and ResolvedP2PRefsInfo = { ProjectReferenceFullPath: string; TargetFramework: string; Others: (string * string) list }
+and ResolvedP2PRefsInfo = { ProjectReferenceFullPath: string; TargetFramework: string option; Others: (string * string) list }
 
 let getNewTempFilePath suffix =
     let outFile = System.IO.Path.GetTempFileName()
@@ -302,13 +302,11 @@ let parseResolvedP2PRefOut outFile =
                     let props = lines |> Map.ofArray
                     let pathOpt = props |> Map.tryFind "ProjectReferenceFullPath"
                     let tfmOpt = props |> Map.tryFind "TargetFramework"
-                    match pathOpt, tfmOpt with
-                    | Some path, Some tfm ->
-                        { ProjectReferenceFullPath = path; TargetFramework = tfm; Others = lines |> List.ofArray }
-                    | Some _, None
-                    | None, Some _
-                    | None, None ->
-                        failwithf "parsing resolved p2p refs, expected properties 'ProjectReferenceFullPath'. 'TargetFramework' not found. Was '%A'" allLines
+                    match pathOpt with
+                    | Some path ->
+                        { ProjectReferenceFullPath = path; TargetFramework = tfmOpt; Others = lines |> List.ofArray }
+                    | None ->
+                        failwithf "parsing resolved p2p refs, expected property 'ProjectReferenceFullPath' not found. Was '%A'" allLines
 
                 )
             |> List.ofArray

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -4,17 +4,17 @@ open System
 open System.IO
 
 #if NET45
-let inline Ok x = Choice1Of2 x
-let inline Error x = Choice2Of2 x
+let inline internal Ok x = Choice1Of2 x
+let inline internal Error x = Choice2Of2 x
 
-let inline (|Ok|Error|) x =
+let inline internal (|Ok|Error|) x =
     match x with
     | Choice1Of2 x -> Ok x
     | Choice2Of2 e -> Error e
 
-type private Result<'Ok,'Err> = Choice<'Ok,'Err>
+type internal Result<'Ok,'Err> = Choice<'Ok,'Err>
 
-module private Result =
+module internal Result =
   let map f inp = match inp with Error e -> Error e | Ok x -> Ok (f x)
   let mapError f inp = match inp with Error e -> Error (f e) | Ok x -> Ok x
   let bind f inp = match inp with Error e -> Error e | Ok x -> f x        

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -305,8 +305,10 @@ let parseResolvedP2PRefOut outFile =
                     match pathOpt, tfmOpt with
                     | Some path, Some tfm ->
                         { ProjectReferenceFullPath = path; TargetFramework = tfm; Others = lines |> List.ofArray }
-                    | _ ->
-                        failwithf "parsing resolved p2p refs, expected properties not found '%A'" allLines
+                    | Some _, None
+                    | None, Some _
+                    | None, None ->
+                        failwithf "parsing resolved p2p refs, expected properties 'ProjectReferenceFullPath'. 'TargetFramework' not found. Was '%A'" allLines
 
                 )
             |> List.ofArray

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -109,6 +109,7 @@ type GetResult =
      | P2PRefs of string list
      | ResolvedP2PRefs of ResolvedP2PRefsInfo list
      | Properties of (string * string) list
+     | ResolvedNETRefs of string list
 and ResolvedP2PRefsInfo = { ProjectReferenceFullPath: string; TargetFramework: string; Others: (string * string) list }
 
 let getNewTempFilePath suffix =

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -110,6 +110,7 @@ type GetResult =
      | ResolvedP2PRefs of ResolvedP2PRefsInfo list
      | Properties of (string * string) list
      | ResolvedNETRefs of string list
+     | InstalledNETFw of string list
 and ResolvedP2PRefsInfo = { ProjectReferenceFullPath: string; TargetFramework: string; Others: (string * string) list }
 
 let getNewTempFilePath suffix =

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -6,6 +6,7 @@ type CLIArguments =
     | Fsc_Args
     | Project_Refs
     | [<AltCommandLine("-gp")>] Get_Property of string list
+    | NET_FW_References_Path of string list
     | [<AltCommandLine("-f")>] Framework of string
     | [<AltCommandLine("-r")>] Runtime of string
     | [<AltCommandLine("-c")>] Configuration of string
@@ -20,6 +21,7 @@ with
             | Project _ -> "the MSBuild project file"
             | Fsc_Args -> "get fsc arguments"
             | Project_Refs -> "get project references"
+            | NET_FW_References_Path _ -> "list the .NET Framework references"
             | Verbose -> "verbose log"
             | Framework _ -> "target framework, the TargetFramework msbuild property"
             | Runtime _ -> "target runtime, the RuntimeIdentifier msbuild property"
@@ -122,10 +124,20 @@ let realMain argv = attempt {
         | Some _ -> printfn "%s"
         | None -> ignore
 
+    let projArgRequired =
+        match results.TryGetResult <@ NET_FW_References_Path @> with
+        | Some _ -> false
+        | None -> true
+
     let! proj =
-        match results.TryGetResult <@ Project @> with
-        | Some p -> Ok p
-        | None ->
+        match results.TryGetResult <@ Project @>, projArgRequired with
+        | Some p, true -> Ok p
+        | Some _, false -> Error (InvalidArgsState "project argument not expected")
+        | None, false ->
+            //create the proj file
+            Ok (Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.createEnvInfoProj ())
+        | None, true ->
+            //scan current directory
             let workDir = Directory.GetCurrentDirectory()
             match Directory.GetFiles(workDir, "*.*proj") |> List.ofArray with
             | [] ->
@@ -170,7 +182,8 @@ let realMain argv = attempt {
     let allCmds =
         [ results.TryGetResult <@ Fsc_Args @> |> Option.map (fun _ -> getFscArgsBySdk)
           results.TryGetResult <@ Project_Refs @> |> Option.map (fun _ -> getP2PRefs)
-          results.TryGetResult <@ Get_Property @> |> Option.map (fun p -> (fun () -> getProperties p)) ]
+          results.TryGetResult <@ Get_Property @> |> Option.map (fun p -> (fun () -> getProperties p))
+          results.TryGetResult <@ NET_FW_References_Path @> |> Option.map (fun props -> (fun () -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.getReferencePaths props)) ]
 
     let msbuildPath = results.GetResult(<@ MSBuild @>, defaultValue = "msbuild")
     let dotnetPath = results.GetResult(<@ DotnetCli @>, defaultValue = "dotnet")
@@ -218,6 +231,7 @@ let realMain argv = attempt {
         | P2PRefs args -> args
         | Properties args -> args |> List.map (fun (x,y) -> sprintf "%s=%s" x y)
         | ResolvedP2PRefs _ -> []
+        | ResolvedNETRefs args -> args
 
     out |> List.iter (printfn "%s")
 

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -175,7 +175,7 @@ let realMain argv = attempt {
             |> Result.Error
 
     let globalArgs =
-        [ results.TryGetResult <@ Framework @>, "TargetFramework"
+        [ results.TryGetResult <@ Framework @>, if isDotnetSdk then "TargetFramework" else "TargetFrameworkVersion"
           results.TryGetResult <@ Runtime @>, "RuntimeIdentifier"
           results.TryGetResult <@ Configuration @>, "Configuration" ]
         |> List.choose (fun (a,p) -> a |> Option.map (fun x -> (p,x)))

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -233,7 +233,10 @@ let realMain argv = attempt {
         | FscArgs args -> args
         | P2PRefs args -> args
         | Properties args -> args |> List.map (fun (x,y) -> sprintf "%s=%s" x y)
-        | ResolvedP2PRefs _ -> []
+        | ResolvedP2PRefs args ->
+            let optionalTfm t =
+                t |> Option.map (sprintf " (%s)") |> Option.defaultValue ""
+            args |> List.map (fun r -> sprintf "%s%s" r.ProjectReferenceFullPath (optionalTfm r.TargetFramework))
         | ResolvedNETRefs args -> args
         | InstalledNETFw args -> args
 

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -7,6 +7,7 @@ type CLIArguments =
     | Project_Refs
     | [<AltCommandLine("-gp")>] Get_Property of string list
     | NET_FW_References_Path of string list
+    | Installed_NET_Frameworks
     | [<AltCommandLine("-f")>] Framework of string
     | [<AltCommandLine("-r")>] Runtime of string
     | [<AltCommandLine("-c")>] Configuration of string
@@ -22,6 +23,7 @@ with
             | Fsc_Args -> "get fsc arguments"
             | Project_Refs -> "get project references"
             | NET_FW_References_Path _ -> "list the .NET Framework references"
+            | Installed_NET_Frameworks -> "list of the installed .NET Frameworks"
             | Verbose -> "verbose log"
             | Framework _ -> "target framework, the TargetFramework msbuild property"
             | Runtime _ -> "target runtime, the RuntimeIdentifier msbuild property"
@@ -125,9 +127,9 @@ let realMain argv = attempt {
         | None -> ignore
 
     let projArgRequired =
-        match results.TryGetResult <@ NET_FW_References_Path @> with
-        | Some _ -> false
-        | None -> true
+        match (results.TryGetResult <@ NET_FW_References_Path @>), (results.TryGetResult<@ Installed_NET_Frameworks @>) with
+        | None, None -> true
+        | _ -> false
 
     let! proj =
         match results.TryGetResult <@ Project @>, projArgRequired with
@@ -183,7 +185,8 @@ let realMain argv = attempt {
         [ results.TryGetResult <@ Fsc_Args @> |> Option.map (fun _ -> getFscArgsBySdk)
           results.TryGetResult <@ Project_Refs @> |> Option.map (fun _ -> getP2PRefs)
           results.TryGetResult <@ Get_Property @> |> Option.map (fun p -> (fun () -> getProperties p))
-          results.TryGetResult <@ NET_FW_References_Path @> |> Option.map (fun props -> (fun () -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.getReferencePaths props)) ]
+          results.TryGetResult <@ NET_FW_References_Path @> |> Option.map (fun props -> (fun () -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.getReferencePaths props))
+          results.TryGetResult <@ Installed_NET_Frameworks @> |> Option.map (fun _ -> Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.installedNETFrameworks) ]
 
     let msbuildPath = results.GetResult(<@ MSBuild @>, defaultValue = "msbuild")
     let dotnetPath = results.GetResult(<@ DotnetCli @>, defaultValue = "dotnet")
@@ -232,6 +235,7 @@ let realMain argv = attempt {
         | Properties args -> args |> List.map (fun (x,y) -> sprintf "%s=%s" x y)
         | ResolvedP2PRefs _ -> []
         | ResolvedNETRefs args -> args
+        | InstalledNETFw args -> args
 
     out |> List.iter (printfn "%s")
 


### PR DESCRIPTION
this add

### find .net framework reference path

cli arg `--net-fw-references-path`, used as `--net-fw-references-path System System.Data`

This support also `-f` (`--framework`) argument, like `-f v4.7`. Note that the value is the target framework versio (`TargetFrameworkVersion` msbuild prop)

### find installed .net framework versions

cli arg `--installed-net-frameworks`
list of the installed .NET Frameworks versions

### fix --project-reference 

now show the project refs

