### PR TITLE
add more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 
-mono: 5.2.0
+mono: 5.12.0
 dotnet: 2.1.401
 
 install:

--- a/build.proj
+++ b/build.proj
@@ -17,7 +17,7 @@
   </Target>
 
   <Target Name="Test">
-    <Exec Command='dotnet run -- "$(Version)" --fail-on-focused-tests' WorkingDirectory="$(RepoRootDir)/test/dotnet-proj-info.Tests" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command='dotnet run -- "$(Version)" --fail-on-focused-tests --summary' WorkingDirectory="$(RepoRootDir)/test/dotnet-proj-info.Tests" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="VSTest" DependsOnTargets="Test" />

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -65,9 +65,10 @@ let getReferencePaths props =
                                |> Result.map (List.map snd >> Inspect.GetResult.ResolvedNETRefs))
 
 
+let [<Literal>] private FrameworkPathOverride = "FrameworkPathOverride"
+
 let installedNETFrameworks () =
-    let prop = "FrameworkPathOverride"
-    let template, args, parser = Inspect.getProperties [prop]
+    let template, args, parser = Inspect.getProperties [FrameworkPathOverride]
 
     let find frameworkPathOverride =
 
@@ -95,8 +96,8 @@ let installedNETFrameworks () =
         |> Result.bind (fun p ->
             match p with
             | Inspect.GetResult.Properties props ->
-                match props |> Map.ofList |> Map.tryFind prop with
-                | None -> Error (Inspect.GetProjectInfoErrors.UnexpectedMSBuildResult (sprintf "expected Property '%s' not found, found: %A" prop props))
+                match props |> Map.ofList |> Map.tryFind FrameworkPathOverride with
+                | None -> Error (Inspect.GetProjectInfoErrors.UnexpectedMSBuildResult (sprintf "expected Property '%s' not found, found: %A" FrameworkPathOverride props))
                 | Some fpo -> Ok (find fpo)
             | r -> Error (Inspect.GetProjectInfoErrors.UnexpectedMSBuildResult (sprintf "expected Properties result, was %A" r)))
 

--- a/src/dotnet-proj-info.sln
+++ b/src/dotnet-proj-info.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -10,6 +10,8 @@ EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Dotnet.ProjInfo", "..\src\Dotnet.ProjInfo\Dotnet.ProjInfo.fsproj", "{6E5ECDBA-8C45-4079-B2E2-81DF3D0A5574}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.ProjInfo.Helpers", "..\src\Dotnet.ProjInfo.Helpers\Dotnet.ProjInfo.Helpers.csproj", "{9275507A-6FC6-46DC-B7CB-DF74D59A4345}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "dotnet-proj-info.Tests", "..\test\dotnet-proj-info.Tests\dotnet-proj-info.Tests.fsproj", "{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +62,18 @@ Global
 		{9275507A-6FC6-46DC-B7CB-DF74D59A4345}.Release|x64.Build.0 = Release|x64
 		{9275507A-6FC6-46DC-B7CB-DF74D59A4345}.Release|x86.ActiveCfg = Release|x86
 		{9275507A-6FC6-46DC-B7CB-DF74D59A4345}.Release|x86.Build.0 = Release|x86
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|x64.Build.0 = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Debug|x86.Build.0 = Debug|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|x64.ActiveCfg = Release|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|x64.Build.0 = Release|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|x86.ActiveCfg = Release|Any CPU
+		{48C692CB-AADC-44FC-9D69-3FAAB12FABB1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{93CBD93B-3FA8-40BE-8C86-2E2A7B748545} = {B72D6D81-119E-482E-9306-E5E2189D1CB7}

--- a/src/dotnet-proj-info/Inspect.fs
+++ b/src/dotnet-proj-info/Inspect.fs
@@ -34,6 +34,7 @@ module MSBuild =
             else s
 
         match a with
+         | Property (k,"") -> sprintf "\"/p:%s=\"" k
          | Property (k,v) -> sprintf "/p:%s=%s" k v |> quote
          | Target t -> sprintf "/t:%s" t |> quote
          | Switch w -> sprintf "/%s" w

--- a/src/dotnet-proj-info/Program.fs
+++ b/src/dotnet-proj-info/Program.fs
@@ -181,6 +181,11 @@ let realMain argv = attempt {
         |> List.choose (fun (a,p) -> a |> Option.map (fun x -> (p,x)))
         |> List.map (MSBuild.MSbuildCli.Property)
 
+    let globalArgs =
+        match Environment.GetEnvironmentVariable("DOTNET_PROJ_INFO_MSBUILD_BL") with
+        | "1" -> MSBuild.MSbuildCli.Switch("bl") :: globalArgs
+        | _ -> globalArgs
+
     let allCmds =
         [ results.TryGetResult <@ Fsc_Args @> |> Option.map (fun _ -> getFscArgsBySdk)
           results.TryGetResult <@ Project_Refs @> |> Option.map (fun _ -> getP2PRefs)

--- a/test/dotnet-proj-info.Tests/FileUtils.fs
+++ b/test/dotnet-proj-info.Tests/FileUtils.fs
@@ -5,6 +5,7 @@ open Expecto.Logging
 open Expecto.Logging.Message
 open Expecto.Impl
 open System
+open System.Runtime.InteropServices
 
 let (/) a b = Path.Combine(a, b)
 
@@ -73,6 +74,13 @@ let shellExecRun (logger: Logger) workDir cmd (args: string list) =
         >> setField "error" cmd.Result.StandardError)
     cmd
 
+let shellExecRunNET (logger: Logger) workDir cmd (args: string list) =
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
+      shellExecRun logger workDir cmd args
+    else
+      shellExecRun logger workDir "mono" (cmd :: args)
+
+
 let createFile (logger: Logger) path setContent =
     logger.info(
       eventX "create file '{path}'"
@@ -107,6 +115,7 @@ type FileUtils (logger: Logger) =
     member __.cp = cp logger
     member __.cp_r = cp_r logger
     member __.shellExecRun = shellExecRun logger currentDirectory
+    member __.shellExecRunNET = shellExecRunNET logger currentDirectory
     member __.createFile = createFile logger
     member __.unzip = unzip logger
     member __.readFile = readFile logger

--- a/test/dotnet-proj-info.Tests/Program.fs
+++ b/test/dotnet-proj-info.Tests/Program.fs
@@ -1,6 +1,7 @@
 ﻿module DotnetMergeNupkg.Program
 
 open Expecto
+open System
 
 [<EntryPoint>]
 let main argv =
@@ -10,4 +11,7 @@ let main argv =
         1
     | pkgUnderTestVersion :: args ->
         printfn "testing package: %s" pkgUnderTestVersion
+
+        Environment.SetEnvironmentVariable("DOTNET_PROJ_INFO_MSBUILD_BL", "1")
+
         Tests.runTestsWithArgs defaultConfig (args |> Array.ofList) (DotnetProjInfo.Tests.tests pkgUnderTestVersion)

--- a/test/dotnet-proj-info.Tests/Program.fs
+++ b/test/dotnet-proj-info.Tests/Program.fs
@@ -13,5 +13,6 @@ let main argv =
         printfn "testing package: %s" pkgUnderTestVersion
 
         Environment.SetEnvironmentVariable("DOTNET_PROJ_INFO_MSBUILD_BL", "1")
+        Environment.SetEnvironmentVariable("MSBuildExtensionsPath", null)
 
         Tests.runTestsWithArgs defaultConfig (args |> Array.ofList) (DotnetProjInfo.Tests.tests pkgUnderTestVersion)

--- a/test/dotnet-proj-info.Tests/Sample.fs
+++ b/test/dotnet-proj-info.Tests/Sample.fs
@@ -93,6 +93,14 @@ let tests pkgUnderTestVersion =
     fs.cd outDir
     outDir
 
+  let asLines (s: string) =
+    s.Split(Environment.NewLine) |> List.ofArray
+
+  let stdOutLines (cmd: Command) =
+    cmd.Result.StandardOutput
+    |> fun s -> s.Trim()
+    |> asLines
+
   [ 
     testList "general" [
       testCase |> withLog "can show help" (fun _ fs ->
@@ -100,6 +108,21 @@ let tests pkgUnderTestVersion =
         projInfo fs ["--help"]
         |> checkExitCodeZero
 
+      )
+    ]
+
+    testList ".net" [
+      testCase |> withLog "can show installed .net frameworks" (fun _ fs ->
+
+        let result = projInfo fs ["--installed-net-frameworks"]
+        result |> checkExitCodeZero
+        let out = stdOutLines result
+
+        let isNETVersion (v: string) =
+          v.StartsWith("v")
+          && v.ToCharArray() |> Array.exists (fun c -> c <> 'v' && c <> '.' <> not (Char.IsNumber c))
+
+        Expect.all out isNETVersion (sprintf "expected a list of .net versions, but was '%A'" out)
       )
     ]
 

--- a/test/dotnet-proj-info.Tests/Sample.fs
+++ b/test/dotnet-proj-info.Tests/Sample.fs
@@ -124,6 +124,19 @@ let tests pkgUnderTestVersion =
 
         Expect.all out isNETVersion (sprintf "expected a list of .net versions, but was '%A'" out)
       )
+
+      testCase |> withLog "can get .net references path" (fun _ fs ->
+
+        let result = projInfo fs ["--installed-net-frameworks"]
+        result |> checkExitCodeZero
+        let netFws = stdOutLines result
+
+        for netfw in netFws do
+          let result = projInfo fs ["--net-fw-references-path"; "System.Core"; "-f"; netfw]
+          result |> checkExitCodeZero
+          let out = stdOutLines result
+          Expect.exists out (fun s -> s.EndsWith("System.Core.dll")) (sprintf "should resolve System.Core.dll but was '%A'" out)
+      )
     ]
 
     testList "old sdk" [

--- a/test/examples/sample1-oldsdk-lib/l1/l1.fsproj
+++ b/test/examples/sample1-oldsdk-lib/l1/l1.fsproj
@@ -63,13 +63,13 @@
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>.\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>.\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
- add test `--installed-net-frameworks`
- add test `--net-fw-references-path`
- use env var `DOTNET_PROJ_INFO_MSBUILD_BL` to generate msbuild binary log
- add hack to disable `FrameworkPathOverride` env var when running `msbuild`. That env var it's a workaround for building `net` tfm with .net core sdk on unix.
- unset env var `MSBuildExtensionsPath`, to fix running `msbuild` on travis otherwise the sdk is overriden with the one in .net core sdk
