### PR TITLE
change cli, use sub commands

### DIFF
--- a/test/dotnet-proj-info.Tests/Program.fs
+++ b/test/dotnet-proj-info.Tests/Program.fs
@@ -2,14 +2,45 @@
 
 open Expecto
 open System
+open System.IO
 
 [<EntryPoint>]
 let main argv =
-    match argv |> List.ofArray with
-    | [] ->
-        printfn "expected packageversion as first argument"
-        1
-    | pkgUnderTestVersion :: args ->
+    let artifactsDir =
+        IO.Path.Combine(__SOURCE_DIRECTORY__,"..","..","bin")
+        |> Path.GetFullPath
+    let nupkgsDir = IO.Path.Combine(artifactsDir,"nupkg")
+
+    let findPackedVersion () =
+        if not (Directory.Exists nupkgsDir) then
+            None
+        else
+            nupkgsDir
+            |> Directory.EnumerateFiles
+            |> Seq.map Path.GetFileNameWithoutExtension
+            |> Seq.tryFind (fun p -> p.StartsWith("dotnet-proj-info"))
+            |> Option.map (fun p -> p.Replace("dotnet-proj-info.",""))
+
+    let info =
+        match argv |> List.ofArray with
+        | pkgUnderTestVersion :: args when Char.IsNumber(pkgUnderTestVersion.[0]) ->
+            printfn "testing package: %s" pkgUnderTestVersion
+            Ok (pkgUnderTestVersion, args)
+        | args ->
+            printfn "Package version not passed as first argument, searching in nupks dir"
+            match findPackedVersion () with
+            | Some v ->
+                printfn "found version '%s' of dotnet-proj-info" v
+                Ok (v, args)
+            | None ->
+                printfn "dotnet-proj-info nupkg not found in '%s'" nupkgsDir
+                Error 1
+
+    match info with
+    | Error exitCode ->
+        printfn "expected package version as first argument, or dotnet-proj-info nupkg in dir '%s'" nupkgsDir
+        exitCode
+    | Ok (pkgUnderTestVersion, args) ->
         printfn "testing package: %s" pkgUnderTestVersion
 
         Environment.SetEnvironmentVariable("DOTNET_PROJ_INFO_MSBUILD_BL", "1")

--- a/test/dotnet-proj-info.Tests/Sample.fs
+++ b/test/dotnet-proj-info.Tests/Sample.fs
@@ -214,7 +214,7 @@ let tests pkgUnderTestVersion =
     testList ".net" [
       testCase |> withLog "can show installed .net frameworks" (fun _ fs ->
 
-        let result = projInfo fs ["--installed-net-frameworks"]
+        let result = projInfo fs ["net-fw"; "--list"]
         result |> checkExitCodeZero
         let out = stdOutLines result
 
@@ -227,12 +227,12 @@ let tests pkgUnderTestVersion =
 
       testCase |> withLog "can get .net references path" (fun _ fs ->
 
-        let result = projInfo fs ["--installed-net-frameworks"]
+        let result = projInfo fs ["net-fw"; "--list"]
         result |> checkExitCodeZero
         let netFws = stdOutLines result
 
         for netfw in netFws do
-          let result = projInfo fs ["--net-fw-references-path"; "System.Core"; "-f"; netfw]
+          let result = projInfo fs ["net-fw"; "--path"; "System.Core"; "-f"; netfw]
           result |> checkExitCodeZero
           let out = stdOutLines result
           Expect.exists out (fun s -> s.EndsWith("System.Core.dll")) (sprintf "should resolve System.Core.dll but was '%A'" out)
@@ -247,7 +247,7 @@ let tests pkgUnderTestVersion =
 
         let projPath = testDir/ (``samples1 OldSdk library``.ProjectFile)
 
-        let result = projInfo fs [projPath; "--get-property"; "AssemblyName"]
+        let result = projInfo fs ["get"; projPath; "--property"; "AssemblyName"]
         result |> checkExitCodeZero
         Expect.equal (sprintf "AssemblyName=%s" ``samples1 OldSdk library``.AssemblyName) (result.Result.StandardOutput.Trim()) "wrong output"
       )
@@ -258,7 +258,7 @@ let tests pkgUnderTestVersion =
 
         let projPath = testDir/ (``samples1 OldSdk library``.ProjectFile)
 
-        let result = projInfo fs [projPath; "--fsc-args"]
+        let result = projInfo fs ["get"; projPath; "--fsc-args"]
         result |> checkExitCodeZero
       )
     ]
@@ -274,7 +274,7 @@ let tests pkgUnderTestVersion =
         dotnet fs ["restore"; projPath]
         |> checkExitCodeZero
 
-        let result = projInfo fs [projPath; "--get-property"; "TargetFramework"]
+        let result = projInfo fs ["get"; projPath; "--property"; "TargetFramework"]
         result |> checkExitCodeZero
         let tfm = ``samples2 NetSdk library``.TargetFrameworks |> Map.toList |> List.map fst |> List.head
         let out = result.Result.StandardOutput.Trim()
@@ -290,7 +290,7 @@ let tests pkgUnderTestVersion =
         dotnet fs ["restore"; projPath]
         |> checkExitCodeZero
 
-        let result = projInfo fs [projPath; "--fsc-args"]
+        let result = projInfo fs ["get"; projPath; "--fsc-args"]
         result |> checkExitCodeZero
       )
 
@@ -303,7 +303,7 @@ let tests pkgUnderTestVersion =
         dotnet fs ["restore"; projPath]
         |> checkExitCodeZero
 
-        let result = projInfo fs [projPath; "--csc-args"]
+        let result = projInfo fs ["get"; projPath; "--csc-args"]
         result |> checkExitCodeZero
       )
 
@@ -317,7 +317,7 @@ let tests pkgUnderTestVersion =
           dotnet fs ["restore"; projPath]
           |> checkExitCodeZero
 
-          let result = projInfo fs [projPath; "-gp"; "OutputPath"; "-c"; conf]
+          let result = projInfo fs ["get"; projPath; "-p"; "OutputPath"; "-c"; conf]
           result |> checkExitCodeZero
           let out = result.Result.StandardOutput.Trim()
 
@@ -335,7 +335,7 @@ let tests pkgUnderTestVersion =
         dotnet fs ["restore"; projPath]
         |> checkExitCodeZero
 
-        let result = projInfo fs [projPath; "--project-refs"]
+        let result = projInfo fs ["get"; projPath; "--project-refs"]
         result |> checkExitCodeZero
 
         let out = stdOutLines result
@@ -357,7 +357,7 @@ let tests pkgUnderTestVersion =
           dotnet fs ["restore"; projPath]
           |> checkExitCodeZero
 
-          let result = projInfo fs [projPath; "--fsc-args"; "-f"; tfm]
+          let result = projInfo fs ["get"; projPath; "--fsc-args"; "-f"; tfm]
           result |> checkExitCodeZero
         )
 
@@ -370,7 +370,7 @@ let tests pkgUnderTestVersion =
           dotnet fs ["restore"; projPath]
           |> checkExitCodeZero
 
-          let result = projInfo fs [projPath; "-f"; tfm; "--get-property"; "MyProperty"]
+          let result = projInfo fs ["get"; projPath; "-f"; tfm; "--property"; "MyProperty"]
           result |> checkExitCodeZero
           let out = result.Result.StandardOutput.Trim()
           let prop = infoOfTfm.Props |> Map.find "MyProperty"


### PR DESCRIPTION
Use sub commands in cli

```
proj-info.
 
USAGE: proj-info [--help] [--verbose] [<subcommand> [<options>]]

SUBCOMMANDS:

    get <options>         get project info
    net-fw <options>      .NET Framework info

    Use 'proj-info <subcommand> --help' for additional information.

OPTIONS:

    --verbose, -v         verbose log
    --help                display this list of options.

```

and

```
proj-info.
 
USAGE: proj-info get [--help] [--fsc-args] [--csc-args] [--project-refs] [--property [<string>...]]
                     [--framework <string>] [--runtime <string>] [--configuration <string>] [--msbuild <string>]
                     [--dotnetcli <string>] [--msbuild-host <auto|msbuild|dotnetmsbuild>] [<string>]

PROJECT:

    <string>              the MSBuild project file

OPTIONS:

    --fsc-args            get fsc arguments
    --csc-args            get csc arguments
    --project-refs, -p2p  get project references
    --property, -p [<string>...]
                          msbuild property to get (allow multiple)
    --framework, -f <string>
                          target framework, the TargetFramework msbuild property
    --runtime, -r <string>
                          target runtime, the RuntimeIdentifier msbuild property
    --configuration, -c <string>
                          configuration to use (like Debug), the Configuration msbuild property
    --msbuild <string>    MSBuild path (default "msbuild")
    --dotnetcli <string>  Dotnet CLI path (default "dotnet")
    --msbuild-host <auto|msbuild|dotnetmsbuild>
                          the Msbuild host, if auto then oldsdk=MSBuild dotnetSdk=DotnetCLI
    --help                display this list of options.

```

and

```
proj-info.
 
USAGE: proj-info net-fw [--help] [--references-path [<string>...]] [--installed] [--msbuild <string>]

OPTIONS:

    --references-path [<string>...]
                          list the .NET Framework references
    --installed           list of the installed .NET Frameworks
    --msbuild <string>    MSBuild path (default "msbuild")
    --help                display this list of options.

```