### PR TITLE
use CustomAfterMicrosoftCommonTargets property as hook

### DIFF
--- a/src/dotnet-proj/Inspect.fs
+++ b/src/dotnet-proj/Inspect.fs
@@ -405,8 +405,17 @@ let getResolvedP2PRefs () =
           Property ("_Inspect_GetResolvedProjectReferences_OutFile", outFile) ]
     template, args, (fun () -> bindSkipped parseResolvedP2PRefOut outFile)
 
+let uninstall_old_target_file log projPath =
+    let projDir, projName = Path.GetDirectoryName(projPath), Path.GetFileName(projPath)
+    let objDir = Path.Combine(projDir, "obj")
+    let targetFileDestPath = Path.Combine(objDir, (sprintf "%s.proj-info.targets" projName))
 
-let getProjectInfos log msbuildExec getters additionalArgs (projPath: string) =
+    log (sprintf "searching deprecated target file in '%s'." targetFileDestPath)
+    if File.Exists targetFileDestPath then
+        log (sprintf "found deprecated target file in '%s', deleting." targetFileDestPath)
+        File.Delete targetFileDestPath
+
+let getProjectInfos log msbuildExec getters additionalArgs projPath =
 
     let templates, argsList, parsers = 
         getters
@@ -414,6 +423,10 @@ let getProjectInfos log msbuildExec getters additionalArgs (projPath: string) =
         |> List.unzip3
 
     let args = argsList |> List.concat
+
+    // remove deprecated target file, if exists
+    projPath
+    |> uninstall_old_target_file log
 
     getNewTempFilePath "proj-info.hook.targets"
     |> writeTargetFile log templates
@@ -423,6 +436,10 @@ let getProjectInfos log msbuildExec getters additionalArgs (projPath: string) =
 let getProjectInfo log msbuildExec getArgs additionalArgs (projPath: string) =
     //TODO refactor to use getProjectInfosOldSdk
     let template, args, parse =  getArgs ()
+
+    // remove deprecated target file, if exists
+    projPath
+    |> uninstall_old_target_file log
 
     getNewTempFilePath "proj-info.hook.targets"
     |> writeTargetFile log [template]

--- a/src/dotnet-proj/Program.fs
+++ b/src/dotnet-proj/Program.fs
@@ -252,13 +252,7 @@ let analizeProj projPath = attempt {
             Errors.GenericError "unsupported project format"
             |> Result.Error
 
-    let getProjectInfoBySdk =
-        if isDotnetSdk then
-            getProjectInfo
-        else
-            getProjectInfoOldSdk
-
-    return isDotnetSdk, pi, getProjectInfoBySdk
+    return isDotnetSdk, pi, getProjectInfo
     }
 
 let propMain log (results: ParseResults<PropCLIArguments>) = attempt {
@@ -477,7 +471,7 @@ let netFwMain log (results: ParseResults<NetFwCLIArguments>) = attempt {
 
     let msbuildHost = MSBuildExePath.Path msbuildPath
 
-    return projPath, getProjectInfoOldSdk, cmd, msbuildHost, []
+    return projPath, getProjectInfo, cmd, msbuildHost, []
     }
 
 let netFwRefMain log (results: ParseResults<NetFwRefCLIArguments>) = attempt {
@@ -499,7 +493,7 @@ let netFwRefMain log (results: ParseResults<NetFwRefCLIArguments>) = attempt {
 
     let msbuildHost = MSBuildExePath.Path msbuildPath
 
-    return projPath, getProjectInfoOldSdk, cmd, msbuildHost, []
+    return projPath, getProjectInfo, cmd, msbuildHost, []
     }
 
 let realMain argv = attempt {

--- a/src/dotnet-proj/Program.fs
+++ b/src/dotnet-proj/Program.fs
@@ -459,11 +459,10 @@ let p2pMain log (results: ParseResults<P2pCLIArguments>) = attempt {
 
 let netFwMain log (results: ParseResults<NetFwCLIArguments>) = attempt {
 
-    let! proj =
+    let projPath =
         //create the proj file
-        Ok (Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.createEnvInfoProj ())
-
-    let projPath = Path.GetFullPath(proj)
+        Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.createEnvInfoProj ()
+        |> Path.GetFullPath
 
     let msbuildPath = results.GetResult(<@ NetFwCLIArguments.MSBuild @>, defaultValue = "msbuild")
 
@@ -481,11 +480,10 @@ let netFwRefMain log (results: ParseResults<NetFwRefCLIArguments>) = attempt {
         | [] -> Error (InvalidArgsState "multiple .*proj found in current directory, use --project argument to specify path")
         | props -> Ok props
 
-    let! proj =
+    let projPath =
         //create the proj file
-        Ok (Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.createEnvInfoProj ())
-
-    let projPath = Path.GetFullPath(proj)
+        Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild.createEnvInfoProj ()
+        |> Path.GetFullPath
 
     let msbuildPath = results.GetResult(<@ NetFwRefCLIArguments.MSBuild @>, defaultValue = "msbuild")
 


### PR DESCRIPTION
fix #10

use `CustomAfterMicrosoftCommonTargets` property as hook instead of a custom target file in `obj` dir, who has issues with incremental rebuild

remove the deprecated target, if found because was in `obj` dir from a previous run