### PR TITLE
normalize api, use `Result` in all target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
 
   <PropertyGroup>
-    <Version Condition=" '$(Version)' == '' ">0.30.0$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">0.31.0$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dotnet.ProjInfo/Inspect.fs
+++ b/src/Dotnet.ProjInfo/Inspect.fs
@@ -3,23 +3,6 @@ module Dotnet.ProjInfo.Inspect
 open System
 open System.IO
 
-#if NET461
-let inline internal Ok x = Choice1Of2 x
-let inline internal Error x = Choice2Of2 x
-
-let inline internal (|Ok|Error|) x =
-    match x with
-    | Choice1Of2 x -> Ok x
-    | Choice2Of2 e -> Error e
-
-type internal Result<'Ok,'Err> = Choice<'Ok,'Err>
-
-module internal Result =
-  let map f inp = match inp with Error e -> Error e | Ok x -> Ok (f x)
-  let mapError f inp = match inp with Error e -> Error (f e) | Ok x -> Ok x
-  let bind f inp = match inp with Error e -> Error e | Ok x -> f x        
-#endif
-
 module MSBuild =
     type MSbuildCli =
          | Property of string * string

--- a/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
+++ b/src/Dotnet.ProjInfo/NETFrameworkInfoFromMSBuild.fs
@@ -3,10 +3,6 @@ module Dotnet.ProjInfo.NETFrameworkInfoFromMSBuild
 open System
 open System.IO
 
-#if NET461
-open Dotnet.ProjInfo.Inspect
-#endif
-
 open Dotnet.ProjInfo.Inspect.MSBuild
 
 let createEnvInfoProj () =


### PR DESCRIPTION
remove usage of `Choice`, use `Result` instead

bump version to v0.31