### PR TITLE
the FSharpProjectOptions.ProjectId is always None

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
@@ -50,7 +50,7 @@ type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
                 f.StartsWith(".NETFramework,Version=v") && f.EndsWith(".AssemblyAttributes.fs")
 
               let fcsPo : FCS_ProjectOptions = {
-                  FCS_ProjectOptions.ProjectId = po.ProjectId
+                  FCS_ProjectOptions.ProjectId = None
                   ProjectFileName = po.ProjectFileName
                   SourceFiles = po.SourceFiles |> List.filter (fun p -> not (isGeneratedTfmAssemblyInfoFile p)) |> Array.ofList
                   OtherOptions = po.OtherOptions |> Array.ofList

--- a/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
@@ -115,6 +115,11 @@ let isOSX () =
   System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
       System.Runtime.InteropServices.OSPlatform.OSX)
 
+let rec allFCSProjects (po: FCS_ProjectOptions) =
+  [ yield po;
+    for (_, p2p) in po.ReferencedProjects do
+      yield! allFCSProjects p2p ]
+
 let tests () =
  
   let prepareTestsAssets = lazy(
@@ -226,6 +231,8 @@ let tests () =
 
         let fcsPo = fcsPoOpt |> Option.get
 
+        Expect.all (allFCSProjects fcsPo) (fun p -> p.ProjectId |> Option.isNone) "all ProjectId are None"
+
         let po =
           loader.Projects
           |> expectFind { ProjectKey.ProjectPath = projPath; TargetFramework = "net461" } "find proj"
@@ -304,6 +311,8 @@ let tests () =
 
         let fcsPo = fcsPoOpt |> Option.get
 
+        Expect.all (allFCSProjects fcsPo) (fun p -> p.ProjectId |> Option.isNone) "all ProjectId are None"
+
         let po =
           loader.Projects
           |> expectFind { ProjectKey.ProjectPath = projPath; TargetFramework = "netstandard2.0" } "first is a lib"
@@ -352,6 +361,8 @@ let tests () =
         logProjectOptions logger fcsPoOpt
 
         let fcsPo = fcsPoOpt |> Option.get
+
+        Expect.all (allFCSProjects fcsPo) (fun p -> p.ProjectId |> Option.isNone) "all ProjectId are None"
 
         let po =
           loader.Projects


### PR DESCRIPTION
compatibility with FSAC