### PR TITLE
fix FCS ProjectOptions of projects with project references

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
@@ -58,8 +58,18 @@ type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
                     po.ReferencedProjects
                      // TODO choose will skip the if not found, should instead log or better
                     |> List.choose (fun key -> getPo { ProjectKey.ProjectPath = key.ProjectFileName; TargetFramework = key.TargetFramework })
-                    // Is (path * projectOption) ok? or was .dll?
-                    |> List.map (fun po -> (key.ProjectPath, po) )
+                    |> List.choose (fun po ->
+                      match po.ExtraProjectInfo with
+                      | None ->
+                        // TODO choose will skip the if not found, should instead log or better
+                        None
+                      | Some dpwPoObj ->
+                        match dpwPoObj with
+                        | :? ProjectOptions as dpwPo ->
+                          Some (dpwPo.ExtraProjectInfo.TargetPath, po)
+                        | _ ->
+                          // TODO choose will skip the if not found, should instead log or better
+                          None)
                     |> Array.ofList
                   IsIncompleteTypeCheckEnvironment = false
                   UseScriptResolutionRules = false

--- a/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
@@ -60,6 +60,7 @@ type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
                     |> List.choose (fun key -> getPo { ProjectKey.ProjectPath = key.ProjectFileName; TargetFramework = key.TargetFramework })
                     // Is (path * projectOption) ok? or was .dll?
                     |> List.map (fun po -> (key.ProjectPath, po) )
+                     // TODO assert the .dll is in the parent project references, otherwise is strange
                     |> Array.ofList
                   IsIncompleteTypeCheckEnvironment = false
                   UseScriptResolutionRules = false

--- a/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
@@ -60,7 +60,6 @@ type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
                     |> List.choose (fun key -> getPo { ProjectKey.ProjectPath = key.ProjectFileName; TargetFramework = key.TargetFramework })
                     // Is (path * projectOption) ok? or was .dll?
                     |> List.map (fun po -> (key.ProjectPath, po) )
-                     // TODO assert the .dll is in the parent project references, otherwise is strange
                     |> Array.ofList
                   IsIncompleteTypeCheckEnvironment = false
                   UseScriptResolutionRules = false
@@ -70,6 +69,8 @@ type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
                   Stamp = None
                   ExtraProjectInfo = Some(box po)
               }
+
+              // TODO sanity check: the p2p .dll are in the parent project references, otherwise is strange
 
               fcsPo
               |> removeDeprecatedArgs

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
@@ -11,7 +11,6 @@ type ProjectSdkType =
     | DotnetSdk of ProjectSdkTypeDotnetSdk
 and ProjectSdkTypeVerbose =
     {
-      TargetPath: string
       TargetFrameworkVersion: string
       Configuration: string
     }
@@ -33,8 +32,6 @@ and ProjectSdkTypeDotnetSdk =
       Configurations: string list // Debug;Release
       TargetFrameworks: string list // netcoreapp1.0;netstandard1.6
 
-      TargetPath: string
-
       //may not exists
       RunArguments: string option // exec "e:\github\DotnetNewFsprojTestingSamples\sdk1.0\sample1\c1\bin\Debug\netcoreapp1.0\c1.dll"
       RunCommand: string option // dotnet
@@ -46,6 +43,7 @@ and ProjectSdkTypeDotnetSdk =
 
 type ExtraProjectInfoData =
     {
+        TargetPath: string
         ProjectOutputType: ProjectOutputType
         ProjectSdkType: ProjectSdkType
     }

--- a/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Program.fs
+++ b/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Program.fs
@@ -12,7 +12,7 @@ let main argv =
 
     let resultsPath = IO.Path.Combine(__SOURCE_DIRECTORY__,"..","..","bin","test_results","Workspace.TestResults.xml")
 
-    let writeResults = TestResults.writeNUnitSummary (resultsPath, "Dotnet.ProjInfo.Workspace.Tests")
+    let writeResults = TestResults.writeNUnitSummary (resultsPath, "Dotnet.ProjInfo.Workspace.FCS.Tests")
     let config = defaultConfig.appendSummaryHandler writeResults
 
     Tests.runTestsWithArgs config argv (Tests.tests ())

--- a/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
@@ -405,7 +405,7 @@ no errors but was: [|commandLineArgs (0,1)-(0,1) parameter error No inputs speci
 
       )
 
-      ftestCase |> withLog "can load sample7" (fun logger fs ->
+      testCase |> withLog "can load sample7" (fun logger fs ->
         let testDir = inDir fs "load_sample7"
         copyDirFromAssets fs ``sample7 Oldsdk projs``.ProjDir testDir
 

--- a/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
@@ -238,7 +238,9 @@ let tests () =
           |> expectFind { ProjectKey.ProjectPath = projPath; TargetFramework = "net461" } "find proj"
 
         Expect.equal fcsPo.LoadTime po.LoadTime "load time"
-        Expect.equal fcsPo.ReferencedProjects.Length po.ReferencedProjects.Length "refs"
+
+        Expect.equal fcsPo.ReferencedProjects.Length ``sample1 OldSdk library``.ProjectReferences.Length "refs"
+
         Expect.equal fcsPo.ExtraProjectInfo (Some (box po)) "extra info"
 
         //TODO check fullpaths
@@ -318,7 +320,9 @@ let tests () =
           |> expectFind { ProjectKey.ProjectPath = projPath; TargetFramework = "netstandard2.0" } "first is a lib"
 
         Expect.equal fcsPo.LoadTime po.LoadTime "load time"
-        Expect.equal fcsPo.ReferencedProjects.Length po.ReferencedProjects.Length "refs"
+
+        Expect.equal fcsPo.ReferencedProjects.Length ``sample2 NetSdk library``.ProjectReferences.Length "refs"
+
         Expect.equal fcsPo.ExtraProjectInfo (Some (box po)) "extra info"
 
         //TODO check fullpaths
@@ -369,7 +373,9 @@ let tests () =
           |> expectFind { ProjectKey.ProjectPath = projPath; TargetFramework = "netcoreapp2.1" } "first is a console app"
 
         Expect.equal fcsPo.LoadTime po.LoadTime "load time"
-        Expect.equal fcsPo.ReferencedProjects.Length (po.ReferencedProjects.Length - 1) "refs" // one is C#, no FSharpProjectOptions for that
+
+        Expect.equal fcsPo.ReferencedProjects.Length (``sample3 Netsdk projs``.ProjectReferences.Length - 1) "only F# refs"  // one is C#, no FSharpProjectOptions for that
+
         Expect.equal fcsPo.ExtraProjectInfo (Some (box po)) "extra info"
 
         //TODO check fullpaths

--- a/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.FCS.Tests/Tests.fs
@@ -260,7 +260,7 @@ let tests () =
       )
 
       testCase |> withLog "do not include generated tfm assemblyinfo" (fun logger fs ->
-        let testDir = inDir fs "load_sample1"
+        let testDir = inDir fs "no_gen_tfm_assemblyinfo"
         copyDirFromAssets fs ``sample1 OldSdk library``.ProjDir testDir
 
         let projPath = testDir/ (``sample1 OldSdk library``.ProjectFile)

--- a/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
@@ -345,7 +345,6 @@ let tests () =
 
         Expect.equal l2Parsed.SourceFiles l2ExpectedSources "check sources"
 
-
         let c1Parsed =
           parsed
           |> expectFind projPath { ProjectKey.ProjectPath = projPath; TargetFramework = "netcoreapp2.1" } "the F# console"

--- a/test/dotnet-proj.Tests/TestAssets.fs
+++ b/test/dotnet-proj.Tests/TestAssets.fs
@@ -129,3 +129,31 @@ let ``sample6 Netsdk Sparse/sln`` =
       ProjectFile = "sample6-netsdk-sparse.sln"
       TargetFrameworks = Map.empty
       ProjectReferences = [] }
+
+/// old sdk, a net461 console MultiProject1
+/// reference:
+/// - net461 lib Project1A (F#)
+/// - net461 lib Project1B (F#)
+let ``sample7 Oldsdk projs`` =
+  { ProjDir = "sample7-oldsdk-projs"
+    AssemblyName = "MultiProject1"
+    ProjectFile = "m1"/"MultiProject1.fsproj"
+    TargetFrameworks =  Map.ofList [
+      "net45", sourceFiles ["MultiProject1.fs"]
+    ]
+    ProjectReferences =
+      [ { ProjDir = "sample7-oldsdk-projs"/"a"
+          AssemblyName = "Project1A"
+          ProjectFile = "a"/"Project1A.fsproj"
+          TargetFrameworks =  Map.ofList [
+            "net45", sourceFiles ["Project1A.fs"]
+          ]
+          ProjectReferences = [] }
+        { ProjDir = "sample7-oldsdk-projs"/"b"
+          AssemblyName = "Project1B"
+          ProjectFile = "b"/"Project1B.fsproj"
+          TargetFrameworks =  Map.ofList [
+            "net45", sourceFiles ["Project1B.fs"]
+          ]
+          ProjectReferences = [] }
+      ] }

--- a/test/examples/sample7-oldsdk-projs/README.md
+++ b/test/examples/sample7-oldsdk-projs/README.md
@@ -1,0 +1,8 @@
+old sdk projects:
+
+a console app `m1/MultiProject1` who reference:
+
+- `a/Project1A` F#
+- `b/Project1B` F#
+
+all targeting `net461`

--- a/test/examples/sample7-oldsdk-projs/a/Project1A.fs
+++ b/test/examples/sample7-oldsdk-projs/a/Project1A.fs
@@ -1,0 +1,5 @@
+module Project1A
+type C() = 
+    static member M(arg1: int, arg2: int, ?arg3 : int) = arg1 + arg2 + defaultArg arg3 4
+let x1 = C.M(arg1 = 3, arg2 = 4, arg3 = 5)
+let x2 = C.M(arg1 = 3, arg2 = 4, ?arg3 = Some 5)

--- a/test/examples/sample7-oldsdk-projs/a/Project1A.fsproj
+++ b/test/examples/sample7-oldsdk-projs/a/Project1A.fsproj
@@ -45,6 +45,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Project1A.fs" />

--- a/test/examples/sample7-oldsdk-projs/a/Project1A.fsproj
+++ b/test/examples/sample7-oldsdk-projs/a/Project1A.fsproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Project1A</RootNamespace>
+    <AssemblyName>Project1A</AssemblyName>
+    <Name>Project1A</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Project1A.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Project1A.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <HintPath>../../../packages/integrationtests/FSharp.Core/lib/net45/FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Project1A.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/test/examples/sample7-oldsdk-projs/b/Project1B.fs
+++ b/test/examples/sample7-oldsdk-projs/b/Project1B.fs
@@ -1,0 +1,7 @@
+module Project1B
+type A = B of xxx: int * yyy : int
+let b = B(xxx=1, yyy=2)
+let x = 
+    match b with
+    // does not find usage here
+    | B (xxx = a; yyy = b) -> ()

--- a/test/examples/sample7-oldsdk-projs/b/Project1B.fsproj
+++ b/test/examples/sample7-oldsdk-projs/b/Project1B.fsproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73db}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Project1B</RootNamespace>
+    <AssemblyName>Project1B</AssemblyName>
+    <Name>Project1B</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\Project1B.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\Project1B.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <HintPath>../../../packages/integrationtests/FSharp.Core/lib/net45/FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Project1B.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/test/examples/sample7-oldsdk-projs/b/Project1B.fsproj
+++ b/test/examples/sample7-oldsdk-projs/b/Project1B.fsproj
@@ -45,6 +45,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Project1B.fs" />

--- a/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fs
+++ b/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fs
@@ -1,0 +1,5 @@
+
+module MultiProject1
+open Project1A
+open Project1B
+let p = (Project1A.x1, Project1B.b)

--- a/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fsproj
+++ b/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fsproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{116cc2f9-f987-4b3d-915a-34cac04a73da}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MultiProject1</RootNamespace>
+    <AssemblyName>MultiProject1</AssemblyName>
+    <Name>MultiProject1</Name>
+    <UsePartialTypes>False</UsePartialTypes>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>False</Optimize>
+    <Tailcalls>False</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Debug\MultiProject1.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>True</Optimize>
+    <Tailcalls>True</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <DocumentationFile>bin\Release\MultiProject1.XML</DocumentationFile>
+    <DebugSymbols>False</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <HintPath>../../../packages/integrationtests/FSharp.Core/lib/net45/FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MultiProject1.fs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <ProjectReference Include="..\a\Project1A.fsproj">
+      <Name>Project1A</Name>
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73da}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\b\Project1B.fsproj">
+      <Name>Project1A</Name>
+      <Project>{116cc2f9-f987-4b3d-915a-34cac04a73db}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+	     Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fsproj
+++ b/test/examples/sample7-oldsdk-projs/m1/MultiProject1.fsproj
@@ -45,6 +45,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MultiProject1.fs" />


### PR DESCRIPTION
fix FCS ProjectOptions of projects with project references

The FCS `ReferencedProjects` key is the project `TargetPath` property (the path of output assembly in `bin`, not `obj`)
