### PR TITLE
support get items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ _Pvt_Extensions
 /test/testrun_ws/
 msbuild.binlog
 /test/testrun_ws_fcs/
+/.ionide/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/dotnet-proj/bin/Debug/netcoreapp2.1/dotnet-proj.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
             "name": "Dotnet.ProjInfo.Workspace.Tests",
             "type": "coreclr",
             "request": "launch",

--- a/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
+++ b/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="CompilerServiceInterface.fs" />
     <Compile Include="ProjectCrackerTypes.fs" />
     <Compile Include="..\..\paket-files\Microsoft\visualfsharp\src\fsharp\FSharp.Build\Fsc.fs" />
+    <Compile Include="VisualTree.fs" />
     <Compile Include="ProjectCrackerDotnetSdk.fs" />
     <Compile Include="InspectSln.fs" />
     <Compile Include="MSbuildInfo.fs" />

--- a/src/Dotnet.ProjInfo.Workspace/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace/Library.fs
@@ -166,7 +166,9 @@ type ProjectViewerTree =
     { Name: string;
       Items: ProjectViewerItem list }
 and [<RequireQualifiedAccess>] ProjectViewerItem =
-    | Compile of string
+    | Compile of string * ProjectViewerItemConfig
+and ProjectViewerItemConfig =
+    { Link: string }
 
 type ProjectViewer () =
 
@@ -196,4 +198,4 @@ type ProjectViewer () =
                 |> List.filter (fun p -> not(isGeneratedAssemblyinfo p))
 
         { ProjectViewerTree.Name = proj.ProjectFileName |> Path.GetFileNameWithoutExtension
-          Items = compileFiles |> List.map ProjectViewerItem.Compile }
+          Items = compileFiles |> List.map(fun p -> ProjectViewerItem.Compile(p, { ProjectViewerItemConfig.Link = p })) }

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
@@ -67,12 +67,15 @@ type ProjectOptions =
         ReferencedProjects: ProjectReference list
         LoadTime: DateTime
         ExtraProjectInfo: ExtraProjectInfoData
+        Items: ProjectItem list
     }
 and ProjectReference =
     {
         ProjectFileName: string
         TargetFramework: string
     }
+and ProjectItem =
+    | Compile of name: string * fullpath: string
 
 type [<RequireQualifiedAccess>] WorkspaceProjectState =
     | Loading of string * ((string * string) list)

--- a/src/Dotnet.ProjInfo.Workspace/VisualTree.fs
+++ b/src/Dotnet.ProjInfo.Workspace/VisualTree.fs
@@ -1,0 +1,66 @@
+namespace Dotnet.ProjInfo.Workspace
+
+module VisualTree =
+
+    open System
+    open System.IO
+    open Dotnet.ProjInfo.Inspect
+
+    // let f1 = @"c:\prova\src\a\a.fs";;
+    // let f2 = @"c:\prova\src\b\b.fs";;
+    // let fsproj = @"c:\prova\src\a\a.fsproj";;
+
+    let getDirEnsureTrailingSlash projPath =
+        let dir = Path.GetDirectoryName(projPath)
+        if dir.EndsWith(Path.DirectorySeparatorChar.ToString()) then
+            dir
+        else
+            dir + Path.DirectorySeparatorChar.ToString()
+
+    let relativePathOf fromPath toPath =
+        let fromUri = Uri(fromPath)
+        let toUri = Uri(toPath)
+        fromUri.MakeRelativeUri(toUri).OriginalString
+
+    let relativeToProjDir projPath filePath =
+        filePath |> relativePathOf (getDirEnsureTrailingSlash projPath)
+
+    let visualPathVSBehaviour projPath filePath =
+        let relativePath = filePath |> relativeToProjDir projPath
+        if relativePath.StartsWith("..") then
+            //if is not a child of proj directory, VS show only the name of the file
+            Path.GetFileName(relativePath)
+        else
+            relativePath
+
+    let getVisualPath linkMetadata fullpathMetadata identity projPath =
+        match linkMetadata, fullpathMetadata with
+        | None, None ->
+            //TODO fullpath was expected, something is wrong. log it
+            identity, identity
+        | Some l, None ->
+            //TODO fullpath was expected, something is wrong. log it
+            l, identity
+        | None, Some path ->
+            //TODO if is not contained in project dir, just show name, to
+            //behave like VS
+            let relativeToPrjDir = path |> visualPathVSBehaviour projPath
+            relativeToPrjDir, path
+        | Some l, Some path ->
+            l, path
+
+    let getProjectItem projPath (p: GetItemResult) : ProjectItem =
+        let tryFindMetadata modifier =
+            p.Metadata
+            |> List.tryFind (fun (m, _) -> m = modifier)
+            |> Option.map snd
+
+        let linkMetadata = tryFindMetadata (GetItemsModifier.Custom("Link"))
+        let fullpathMetadata = tryFindMetadata (GetItemsModifier.FullPath)
+
+        let projDir = Path.GetDirectoryName(projPath)
+
+        let (name, fullpath) = projDir |> getVisualPath linkMetadata fullpath p.Identity 
+
+        ProjectItem.Compile (name, fullpath)
+

--- a/src/dotnet-proj/Program.fs
+++ b/src/dotnet-proj/Program.fs
@@ -353,13 +353,15 @@ let itemMain log (results: ParseResults<ItemCLIArguments>) = attempt {
             p, modifier
         | _ -> failwithf "Unexpected item path '%s'. Expected format is 'ItemName' or 'ItemName.Metadata' (like Compile.Identity or Compile.FullPath)" path
 
-    let itemPath = results.GetResult <@ ItemCLIArguments.GetItem @>
-
-    let item, modifier = parseItemPath itemPath
+    let items =
+        results.GetResults <@ ItemCLIArguments.GetItem @>
+        |> List.map (fun itemPath ->
+            let item, modifier = parseItemPath itemPath
+            itemPath, item, modifier)
 
     let dependsOn = results.GetResults <@ ItemCLIArguments.Depends_On @>
 
-    let cmd () = getItems itemPath item modifier dependsOn
+    let cmd () = getItems items dependsOn
 
     let rec msbuildHost host =
         match host with

--- a/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
+++ b/test/Dotnet.ProjInfo.Workspace.Tests/Tests.fs
@@ -923,7 +923,7 @@ let tests (suiteConfig: TestSuiteConfig) =
         Expect.equal (viewer.Render l2Parsed) (renderOf l2Proj []) "check rendered l2"
       )
 
-      ftestCase |> withLog "can render sample8" (fun logger fs ->
+      testCase |> withLog "can render sample8" (fun logger fs ->
         let testDir = inDir fs "render_sample8"
         let sampleProj = ``sample8 NetSdk Explorer``
         copyDirFromAssets fs sampleProj.ProjDir testDir

--- a/test/dotnet-proj.Tests/TestAssets.fs
+++ b/test/dotnet-proj.Tests/TestAssets.fs
@@ -157,3 +157,13 @@ let ``sample7 Oldsdk projs`` =
           ]
           ProjectReferences = [] }
       ] }
+
+/// dotnet sdk, one netstandard2.0 lib n1 with advanced solution explorer configurations
+let ``sample8 NetSdk Explorer`` =
+  { ProjDir = "sample8-netsdk-explorer"
+    AssemblyName = "n1"
+    ProjectFile = "n1"/"n1.fsproj"
+    TargetFrameworks =  Map.ofList [
+      "netstandard2.0", sourceFiles ["LibraryA.fs"; "LibraryC.fs"; "LibraryB.fs"]
+    ]
+    ProjectReferences = [] }

--- a/test/examples/sample8-netsdk-explorer/README.md
+++ b/test/examples/sample8-netsdk-explorer/README.md
@@ -1,0 +1,10 @@
+a simple library (.net sdk) targeting `netstandard2.0` with advanced solution explorer configurations
+
+```
+- Component
+  \- TheLibraryA.fs
+- LibraryC.fs
+- Component
+  \- Auth
+     \- TheLibraryB.fs
+```

--- a/test/examples/sample8-netsdk-explorer/n1/LibraryA.fs
+++ b/test/examples/sample8-netsdk-explorer/n1/LibraryA.fs
@@ -1,0 +1,5 @@
+namespace n1
+
+module SayA =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample8-netsdk-explorer/n1/LibraryB.fs
+++ b/test/examples/sample8-netsdk-explorer/n1/LibraryB.fs
@@ -1,0 +1,5 @@
+namespace n1
+
+module SayB =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample8-netsdk-explorer/n1/LibraryC.fs
+++ b/test/examples/sample8-netsdk-explorer/n1/LibraryC.fs
@@ -1,0 +1,5 @@
+namespace n1
+
+module SayC =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/examples/sample8-netsdk-explorer/n1/n1.fsproj
+++ b/test/examples/sample8-netsdk-explorer/n1/n1.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="LibraryA.fs">
+      <Link>Component/TheLibraryA.fs</Link>
+    </Compile>
+    <Compile Include="LibraryC.fs" />
+    <Compile Include="LibraryB.fs">
+      <Link>Component\Auth\TheLibraryB.fs</Link>
+    </Compile>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## dotnet proj

- add `dotnet proj item` command 

## Inpect library

- add `Inspect.getItems` to get msbuild items
- support multiple metadata and items in same query
- support depends on targets, to hook at different positions

## ProjectViewer

- each item return as additional info the expected virtual path for visualization
- same VS behaviour for compile file outside fsproj directory (not in subdirectory). The virtual path will show only the file name.
- virtual paths use `/` as dir separator
- support `Link` metadata


fix #53