### PR TITLE
add rollforward config to allow for netcore3 running

### DIFF
--- a/src/dotnet-proj/runtimeconfig.template.json
+++ b/src/dotnet-proj/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+    // '2' allows for major-version roll-forward
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Right now, dotnet-proj doesn't run on .net core 3 runtimes because it's not built for that yet.  This MR provides a runtimeconfig template file that's used by the build to set the roll-forward policy for the application, so now it work on the next-major-version as well, so any 3.x runtime.  This is intended to be a temporary measure until the project can be properly cross-targeted on release.