### PR TITLE
move fcs binder in DPI.Workspace

### DIFF
--- a/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
+++ b/src/Dotnet.ProjInfo.Workspace.FCS/Library.fs
@@ -6,105 +6,26 @@ open System.Collections.Generic
 type FCS_ProjectOptions = FSharp.Compiler.SourceCodeServices.FSharpProjectOptions
 type FCS_Checker = FSharp.Compiler.SourceCodeServices.FSharpChecker
 
-module internal FscArguments =
+module internal FCSPoHelpers =
 
-    let isTempFile (name: string) =
-        let tempPath = System.IO.Path.GetTempPath()
-        let s = name.ToLower()
-        s.StartsWith(tempPath.ToLower())
-
-    let isDeprecatedArg n =
-      // TODO put in FCS
-      (n = "--times") || (n = "--no-jit-optimize")
+  let rec fcsPoMapper (fcsPoData: FCSProjectOptionsData) : FCS_ProjectOptions =
+      { FCS_ProjectOptions.ProjectId = fcsPoData.ProjectId
+        ProjectFileName = fcsPoData.ProjectFileName
+        SourceFiles = fcsPoData.SourceFiles
+        OtherOptions = fcsPoData.OtherOptions
+        ReferencedProjects =
+          fcsPoData.ReferencedProjects
+          |> Array.map (fun (p, d) -> p, (fcsPoMapper d))
+        IsIncompleteTypeCheckEnvironment = fcsPoData.IsIncompleteTypeCheckEnvironment
+        UseScriptResolutionRules = fcsPoData.UseScriptResolutionRules
+        LoadTime = fcsPoData.LoadTime
+        UnresolvedReferences = None // it's always None
+        OriginalLoadReferences = [] // it's always empty list
+        Stamp = fcsPoData.Stamp
+        ExtraProjectInfo = fcsPoData.ExtraProjectInfo }
 
 type FCSBinder (netFwInfo: NetFWInfo, workspace: Loader, checker: FCS_Checker) =
-
-    let removeDeprecatedArgs (opts: FCS_ProjectOptions) =
-      // TODO add test
-      let oos =
-        opts.OtherOptions
-        |> Array.filter (fun n -> not (FscArguments.isDeprecatedArg n))
-      { opts with OtherOptions = oos }
-
-    member this.GetProjectOptions(path: string) =
-        let parsed = workspace.Projects
-
-        let byKey key (kv: KeyValuePair<ProjectKey, ProjectOptions>) =
-          if kv.Key = key then
-            Some kv
-          else
-            None
-
-        let rec getPoByKey (key:ProjectKey) : Result<FCS_ProjectOptions, GetProjectOptionsErrors> =
-            match parsed |> Array.tryPick (byKey key) with
-            | None -> Error (ProjectNotLoaded key.ProjectPath)
-            | Some kv -> getPo kv
-        and getPo (kv: KeyValuePair<ProjectKey, ProjectOptions>) : Result<FCS_ProjectOptions, GetProjectOptionsErrors> =
-          match kv.Value with
-          | po when not (po.ProjectFileName.EndsWith(".fsproj")) ->
-              Error (LanguageNotSupported po.ProjectFileName)
-          | po ->
-
-              let isGeneratedTfmAssemblyInfoFile path =
-                let f = System.IO.Path.GetFileName(path)
-                f.StartsWith(".NETFramework,Version=v") && f.EndsWith(".AssemblyAttributes.fs")
-
-              let refs =
-                po.ReferencedProjects
-                |> List.map (fun key ->
-                  getPoByKey { ProjectKey.ProjectPath = key.ProjectFileName; TargetFramework = key.TargetFramework }
-                  |> Result.bind (fun po ->
-                    match po.ExtraProjectInfo with
-                    | Some (:? ProjectOptions as dpwPo) -> Ok (dpwPo.ExtraProjectInfo.TargetPath, po)
-                    | Some s -> Error (InvalidExtraProjectInfos (po.ProjectFileName, sprintf "cannot cast to ProjectOptions, was %s" (if isNull s then "<NULL>" else s.GetType().FullName)))
-                    | None -> Error (MissingExtraProjectInfos po.ProjectFileName))
-                  )
-
-              // maybe don't fail on every error, currently we only ignore LanguageNotSupported
-              let errors = refs |> List.choose (function
-                | Error (LanguageNotSupported _) -> None // ignore references into other languages
-                | Error err -> Some (err.ProjFile, err)
-                | _ -> None)
-              if errors.Length > 0 then
-                Error (ReferencesNotLoaded (po.ProjectFileName, errors))
-              else
-                let realRefs = refs |> List.choose (function Ok p -> Some p | _ -> None) |> List.toArray
-
-                let fcsPo : FCS_ProjectOptions = {
-                    FCS_ProjectOptions.ProjectId = None
-                    ProjectFileName = po.ProjectFileName
-                    SourceFiles = po.SourceFiles |> List.filter (fun p -> not (isGeneratedTfmAssemblyInfoFile p)) |> Array.ofList
-                    OtherOptions = po.OtherOptions |> Array.ofList
-                    ReferencedProjects = realRefs
-                    IsIncompleteTypeCheckEnvironment = false
-                    UseScriptResolutionRules = false
-                    LoadTime = po.LoadTime
-                    UnresolvedReferences = None
-                    OriginalLoadReferences = []
-                    Stamp = None
-                    ExtraProjectInfo = Some(box po)
-                }
-
-                // TODO sanity check: the p2p .dll are in the parent project references, otherwise is strange
-
-                fcsPo
-                |> removeDeprecatedArgs
-                // TODO check use full paths?
-                |> Ok
-
-        let byPath path (kv: KeyValuePair<ProjectKey, ProjectOptions>) =
-          if kv.Key.ProjectPath = path then
-            Some kv
-          else
-            None
-
-        match parsed |> Array.tryPick (byPath path) with
-        | Some po -> getPo po
-        | None ->
-          match workspace.LastError path with
-          | Some e -> Error e
-          | None -> Error (ProjectNotLoaded path)
-
+    inherit FCSAdapter<FCS_ProjectOptions>(workspace, FCSPoHelpers.fcsPoMapper)
 
 type FsxBinder (netFwInfo: NetFWInfo, checker: FCS_Checker) =
 

--- a/src/Dotnet.ProjInfo.Workspace/Binder.fs
+++ b/src/Dotnet.ProjInfo.Workspace/Binder.fs
@@ -1,0 +1,137 @@
+namespace Dotnet.ProjInfo.Workspace
+
+open System
+open System.Collections.Generic
+
+type FCSProjectOptionsData =
+    {
+      // Note that this may not reduce to just the project directory, because there may be two projects in the same directory.
+      ProjectFileName: string
+
+      /// This is the unique identifier for the project, it is case sensitive. If it's None, will key off of ProjectFileName in our caching.
+      ProjectId: string option
+
+      /// The files in the project
+      SourceFiles: string[]
+
+      /// Additional command line argument options for the project. These can include additional files and references.
+      OtherOptions: string[]
+
+      /// The command line arguments for the other projects referenced by this project, indexed by the
+      /// exact text used in the "-r:" reference in FSharpProjectOptions.
+      ReferencedProjects: (string * FCSProjectOptionsData)[]
+
+      /// When true, the typechecking environment is known a priori to be incomplete, for
+      /// example when a .fs file is opened outside of a project. In this case, the number of error
+      /// messages reported is reduced.
+      IsIncompleteTypeCheckEnvironment : bool
+
+      /// When true, use the reference resolution rules for scripts rather than the rules for compiler.
+      UseScriptResolutionRules : bool
+
+      /// Timestamp of project/script load, used to differentiate between different instances of a project load.
+      /// This ensures that a complete reload of the project or script type checking
+      /// context occurs on project or script unload/reload.
+      LoadTime : DateTime
+
+      /// Unused in this API and should be 'None' when used as user-specified input
+      UnresolvedReferences : obj option
+
+      /// Unused in this API and should be '[]' when used as user-specified input
+      OriginalLoadReferences: obj list
+
+      /// Extra information passed back on event trigger
+      ExtraProjectInfo : obj option
+
+      /// An optional stamp to uniquely identify this set of options
+      /// If two sets of options both have stamps, then they are considered equal
+      /// if and only if the stamps are equal
+      Stamp: int64 option
+    }
+
+type FCSAdapter<'FCSProjectOptions>(workspace: Loader, toFCSPoMapper: FCSProjectOptionsData -> 'FCSProjectOptions) =
+
+    member this.GetProjectOptions(path: string) : Result<'FCSProjectOptions, GetProjectOptionsErrors> =
+        let parsed = workspace.Projects
+
+        let byKey key (kv: KeyValuePair<ProjectKey, ProjectOptions>) =
+          if kv.Key = key then
+            Some kv
+          else
+            None
+
+        let rec getPoByKey (key:ProjectKey) : Result<FCSProjectOptionsData, GetProjectOptionsErrors> =
+            match parsed |> Array.tryPick (byKey key) with
+            | None -> Error (ProjectNotLoaded key.ProjectPath)
+            | Some kv -> getPo kv
+        and getPo (kv: KeyValuePair<ProjectKey, ProjectOptions>) : Result<FCSProjectOptionsData, GetProjectOptionsErrors> =
+          match kv.Value with
+          | po when not (po.ProjectFileName.EndsWith(".fsproj")) ->
+              Error (LanguageNotSupported po.ProjectFileName)
+          | po ->
+
+              let isGeneratedTfmAssemblyInfoFile path =
+                let f = System.IO.Path.GetFileName(path)
+                f.StartsWith(".NETFramework,Version=v") && f.EndsWith(".AssemblyAttributes.fs")
+
+              let refs =
+                po.ReferencedProjects
+                |> List.map (fun key ->
+                  getPoByKey { ProjectKey.ProjectPath = key.ProjectFileName; TargetFramework = key.TargetFramework }
+                  |> Result.bind (fun (po: FCSProjectOptionsData) ->
+                    match po.ExtraProjectInfo with
+                    | Some (:? ProjectOptions as dpwPo) -> Ok (dpwPo.ExtraProjectInfo.TargetPath, po)
+                    | Some s -> Error (InvalidExtraProjectInfos (po.ProjectFileName, sprintf "cannot cast to ProjectOptions, was %s" (if isNull s then "<NULL>" else s.GetType().FullName)))
+                    | None -> Error (MissingExtraProjectInfos po.ProjectFileName))
+                  )
+
+              // maybe don't fail on every error, currently we only ignore LanguageNotSupported
+              let errors = refs |> List.choose (function
+                | Error (LanguageNotSupported _) -> None // ignore references into other languages
+                | Error err -> Some (err.ProjFile, err)
+                | _ -> None)
+              if errors.Length > 0 then
+                Error (ReferencesNotLoaded (po.ProjectFileName, errors))
+              else
+                let realRefs = refs |> List.choose (function Ok p -> Some p | _ -> None) |> List.toArray
+
+                let fcsPoData : FCSProjectOptionsData = {
+                    FCSProjectOptionsData.ProjectId = None
+                    ProjectFileName = po.ProjectFileName
+                    SourceFiles =
+                        po.SourceFiles
+                        |> List.filter (fun p -> not (isGeneratedTfmAssemblyInfoFile p))
+                        |> Array.ofList
+                    OtherOptions =
+                        po.OtherOptions
+                        |> List.filter (fun n -> not (FscArguments.isDeprecatedArg n))
+                        |> Array.ofList
+                    ReferencedProjects = realRefs
+                    IsIncompleteTypeCheckEnvironment = false
+                    UseScriptResolutionRules = false
+                    LoadTime = po.LoadTime
+                    UnresolvedReferences = None
+                    OriginalLoadReferences = []
+                    Stamp = None
+                    ExtraProjectInfo = Some(box po)
+                }
+
+                // TODO sanity check: the p2p .dll are in the parent project references, otherwise is strange
+                // TODO check use full paths?
+
+                Ok fcsPoData
+
+        let byPath path (kv: KeyValuePair<ProjectKey, ProjectOptions>) =
+          if kv.Key.ProjectPath = path then
+            Some kv
+          else
+            None
+
+        match parsed |> Array.tryPick (byPath path) with
+        | Some po ->
+            getPo po
+            |> Result.map toFCSPoMapper
+        | None ->
+          match workspace.LastError path with
+          | Some e -> Error e
+          | None -> Error (ProjectNotLoaded path)

--- a/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
+++ b/src/Dotnet.ProjInfo.Workspace/Dotnet.ProjInfo.Workspace.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="InspectSln.fs" />
     <Compile Include="MSbuildInfo.fs" />
     <Compile Include="Library.fs" />
+    <Compile Include="Binder.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
+++ b/src/Dotnet.ProjInfo.Workspace/ProjectCrackerTypes.fs
@@ -162,3 +162,12 @@ module internal FscArguments =
             s |> makeAbs projDir |> Path.GetFullPath
         else
             s
+
+  let isTempFile (name: string) =
+      let tempPath = System.IO.Path.GetTempPath()
+      let s = name.ToLower()
+      s.StartsWith(tempPath.ToLower())
+
+  let isDeprecatedArg n =
+    // TODO put in FCS
+    (n = "--times") || (n = "--no-jit-optimize")


### PR DESCRIPTION
allow to use `DPI.Workspace.FCSAdapter` like `DPI.Workspace.FCS.FCSBinder`, without reference FCS package

users of `DPI.Workspace.FCSAdapter` need to provider a mapper function `FCSProjectOptionsData -> FCS.FSharpProjectOptions`, but the two types are structural equivalent so is simple